### PR TITLE
update: 不要なdbサービス定義をcompose.ymlから削除

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true,
+    "source.organizeImports": true
+  },
+  "prettier.configPath": ".prettier.json",
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/compose.yml
+++ b/compose.yml
@@ -1,15 +1,4 @@
 services:
-  db:
-    image: mysql:8.0.36
-    environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-    ports:
-      - "3306:3306"
-    volumes:
-      - mysql_data:/var/lib/mysql
   back:
     build:
       context: ./back
@@ -39,5 +28,3 @@ services:
     command: yarn dev -p 4000
     ports:
       - "8000:4000"
-volumes:
-  mysql_data:


### PR DESCRIPTION
close #45 

PlanetScaleのデータベースはクラウド上に存在し、ローカルでDockerコンテナとして実行されるものではない。
よってcompose.ymlにdbサービスの定義は不要なため、削除。