### PR TITLE
fix: compose.yml修正

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -15,8 +15,6 @@ services:
       - /etc/ssl/cert.pem:/etc/ssl/cert.pem
     ports:
       - "3000:3000"
-    depends_on:
-      - db
     tty: true
     stdin_open: true
   front:


### PR DESCRIPTION
dbサービスの定義削除に伴い、backサービス内でのdepends_onの定義が不要となったため、削除しました。