### PR TITLE
remove: .gitmodules削除

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "front"]
-	path = front
-	url = git@github.com:meimei-kr/idea-space-trip_front.git
-[submodule "back"]
-	path = back
-	url = git@github.com:meimei-kr/idea-space-trip_back.git


### PR DESCRIPTION
モノリポ構成に変更したため、サブモジュールの設定は不要となりました。
それに伴い、 `.gitmodules` を削除しました。