### PR TITLE
fix: Parsing Errorの解消

### DIFF
--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -3,6 +3,8 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "next/core-web-vitals",
-    "prettier"
+    "prettier",
+    "next",
+    "next/babel"
   ]
 }


### PR DESCRIPTION
【問題】
`next.config.ujs` ファイルにおいて、`Parsing error: Cannot find module 'next/babel'`エラーが発生していました。

【対処方法】
`.eslintrc.json` に `"next"` と `"next/babel"`を追加することでエラーが解消できました。