### PR TITLE
update: サーバーが停止しないようfly.tomlを修正

### DIFF
--- a/back/fly.toml
+++ b/back/fly.toml
@@ -12,7 +12,7 @@ console_command = "/rails/bin/rails console"
 [http_service]
   internal_port = 3000
   force_https = true
-  auto_stop_machines = true
+  auto_stop_machines = false
   auto_start_machines = true
   min_machines_running = 0
   processes = ["app"]

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -1,4 +1,4 @@
-import styles from "@/app/page.module.css";
+import styles from "@/app/page.module.scss";
 import Login from "@/components/Login";
 import Logout from "@/components/Logout";
 import { authOptions } from "@/lib/options";


### PR DESCRIPTION
## issue番号
close #91

## やったこと
`auto_stop_machines = false` にすることで、サーバーが停止しないようにしました。

## やらないこと
なし

## できるようになること（ユーザ目線）
なし

## できなくなること（ユーザ目線）
なし

## 動作確認
`fly deploy` を実行し、サーバーが起動し続けることを確認しました。

## その他
なし
