### PR TITLE
fix: トップページ・フッターレイアウト崩れ修正 #100

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -21,8 +21,8 @@ jobs:
           debug: false
           review_simple_changes: false
           review_comment_lgtm: false
-          openai_light_model: gpt-4
-          openai_heavy_model: gpt-4
+          openai_light_model: gpt-3.5-turbo # 要約用モデル
+          openai_heavy_model: gpt-3.5-turbo # レビュー用モデル
           openai_timeout_ms: 900000 # 15分
           language: ja-JP
           path_filters: |

--- a/front/src/app/globals.scss
+++ b/front/src/app/globals.scss
@@ -91,6 +91,7 @@
 html,
 body {
   height: 100%;
+  width: 100vw;
   min-height: 100%;
   box-sizing: border-box;
   margin: 0;

--- a/front/src/app/presentation/Home/HomePresentation.module.scss
+++ b/front/src/app/presentation/Home/HomePresentation.module.scss
@@ -219,6 +219,7 @@ $earth-width: 100%;
 .aboutImg {
   width: 50%;
   height: auto;
+  display: inline-block;
 
   @media screen and (min-width: 1024px) {
     width: 30%;
@@ -267,56 +268,82 @@ $earth-width: 100%;
   }
 }
 
-/* クォーテーション画像 */
+/* クォーテーションエリア */
 .quoteArea {
-  p {
+  margin: 8px 0;
+}
+
+.quoteItem {
+  height: 40px;
+
+  @media screen and (min-width: 768px) {
+    height: 44px;
+  }
+
+  @media screen and (min-width: 1024px) {
+    height: 48px;
+  }
+
+  span {
+    display: inline-block;
     font-size: 18px;
-    height: 24px;
+    line-height: 40px;
+    position: relative;
+    padding: 0 28px;
+    height: 100%;
 
     @media screen and (min-width: 768px) {
       font-size: 20px;
-      height: 28px;
+      padding: 0 32px;
+      line-height: 44px;
     }
 
     @media screen and (min-width: 1024px) {
       font-size: 24px;
-      height: 32px;
+      padding: 0 44px;
+      line-height: 48px;
     }
   }
 }
 
 .quoteStart {
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   margin-right: 6px;
+  position: absolute;
+  top: 0;
+  left: 0;
 
   @media screen and (min-width: 768px) {
-    width: 28px;
-    height: 28px;
+    width: 24px;
+    height: 24px;
     margin-right: 8px;
   }
 
   @media screen and (min-width: 1024px) {
-    width: 32px;
-    height: 32px;
+    width: 28px;
+    height: 28px;
     margin-right: 16px;
   }
 }
 
 .quoteEnd {
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   margin-left: 6px;
+  position: absolute;
+  bottom: 0;
+  right: 0;
 
   @media screen and (min-width: 768px) {
-    width: 28px;
-    height: 28px;
+    width: 24px;
+    height: 24px;
     margin-left: 8px;
   }
 
   @media screen and (min-width: 1024px) {
-    width: 32px;
-    height: 32px;
+    width: 28px;
+    height: 28px;
     margin-left: 16px;
   }
 }

--- a/front/src/app/presentation/Home/HomePresentation.tsx
+++ b/front/src/app/presentation/Home/HomePresentation.tsx
@@ -46,36 +46,32 @@ export function HomePresentation({ session }: { session: Session | null }) {
               </div>
             </div>
             <div className={styles.quoteArea}>
-              <p>
+              <div className={styles.quoteItem}>
                 <span>
+                  解決したい課題がある
                   <QuoteStart
                     className={styles.quoteStart}
                     data-testid="quote-start"
                   />
-                </span>
-                解決したい課題がある
-                <span>
                   <QuoteEnd
                     className={styles.quoteEnd}
                     data-testid="quote-end"
                   />
                 </span>
-              </p>
-              <p>
+              </div>
+              <div className={styles.quoteItem}>
                 <span>
+                  こんなことができたらいいのに
                   <QuoteStart
                     className={styles.quoteStart}
                     data-testid="quote-start"
                   />
-                </span>
-                こんなことができたらいいのに
-                <span>
                   <QuoteEnd
                     className={styles.quoteEnd}
                     data-testid="quote-end"
                   />
                 </span>
-              </p>
+              </div>
             </div>
             <p className={styles.description}>
               そんな風に思いながら、具体的にどんなことをしたらいいのかアイデアに詰まってしまっていませんか？

--- a/front/src/app/presentation/SelectMode/SelectModePresentation.test.tsx
+++ b/front/src/app/presentation/SelectMode/SelectModePresentation.test.tsx
@@ -21,7 +21,7 @@ jest.mock("@/lib/idea-sessions");
 
 describe("SelectMode", () => {
   it("renders the correct text content", () => {
-    render(<SelectModePresentation sessionInProgress={null} />);
+    render(<SelectModePresentation />);
     expect(screen.getByText("アイデア出し")).toBeInTheDocument();
     expect(screen.getByText("スタート")).toBeInTheDocument();
     expect(screen.getByText("アイデア")).toBeInTheDocument();
@@ -29,7 +29,7 @@ describe("SelectMode", () => {
   });
 
   it("should render two LinkButton components", () => {
-    render(<SelectModePresentation sessionInProgress={null} />);
+    render(<SelectModePresentation />);
     const linkButton = screen.getByTestId("linkButton");
     const button = screen.getByTestId("button");
 

--- a/front/src/app/presentation/SelectMode/SelectModePresentation.tsx
+++ b/front/src/app/presentation/SelectMode/SelectModePresentation.tsx
@@ -3,7 +3,7 @@
 import styles from "@/app/presentation/SelectMode/SelectModePresentation.module.scss";
 import Button from "@/components/elements/Button/Button";
 import LinkButton from "@/components/elements/LinkButton/LinkButton";
-import { ToastAction, ToastClose } from "@/components/ui/toast";
+import { ToastAction } from "@/components/ui/toast";
 import { useToast } from "@/components/ui/use-toast";
 import {
   ANSWER_GENERATED_COUNT_LIMIT,
@@ -81,7 +81,6 @@ export function SelectModePresentation() {
       // 制限回数に達している場合、エラーメッセージを表示
       toast({
         duration: 10000,
-        close: <ToastClose> ✕ </ToastClose>,
         title: "AI利用回数制限超過",
         description:
           "頑張ったので、今日はAI利用回数制限に達したよ。出したアイデアをふりかえってみよう。",

--- a/front/src/components/layouts/Footer/Footer.module.scss
+++ b/front/src/components/layouts/Footer/Footer.module.scss
@@ -28,6 +28,7 @@
 .sns {
   display: grid;
   grid-template-columns: 1fr;
+  gap: 16px;
 
   p {
     margin-top: 0;

--- a/front/src/components/layouts/Header/Header.tsx
+++ b/front/src/components/layouts/Header/Header.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import styles from "@/components/layouts/Header/Header.module.scss";
-import { ToastClose, ToastAction } from "@/components/ui/toast";
+import { ToastAction } from "@/components/ui/toast";
 import { toast } from "@/components/ui/use-toast";
 import {
-  THEME_GENERATED_COUNT_LIMIT,
   ANSWER_GENERATED_COUNT_LIMIT,
+  THEME_GENERATED_COUNT_LIMIT,
 } from "@/constants/constants";
 import { useDialog } from "@/hooks/useDialog";
 import { getAIUsageHistory } from "@/lib/ai-usage-history";
@@ -95,7 +95,6 @@ export default function Header() {
       // 制限回数に達している場合、エラーメッセージを表示
       toast({
         duration: 10000,
-        close: <ToastClose> ✕ </ToastClose>,
         title: "AI利用回数制限超過",
         description:
           "頑張ったので、今日はAI利用回数制限に達したよ。出したアイデアをふりかえってみよう。",


### PR DESCRIPTION
## issue番号
close #100

## やったこと
トップページ・フッターのレイアウト崩れを修正しました。

## やらないこと
なし

## できるようになること（ユーザ目線）
レイアウト崩れなく、トップページとフッターが表示されるようになります。

## できなくなること（ユーザ目線）
なし

## 動作確認
レイアウト崩れが修正されていることを確認しました。

## その他
なし

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Refactor: OpenAIのモデルを gpt-4 から gpt-3.5-turbo に変更し、コメントを明確化
- Style: `width: 100vw;`を追加して`html`と`body`要素の幅を調整
- Style: トップページとフッターのレイアウト修正に関するスタイルシートを更新
- Refactor: トップページの引用部分のHTML構造を修正
- Refactor: `SelectModePresentation`コンポーネント内で不要な`ToastClose`コンポーネントを削除
- Style: `gap: 16px;`を`Footer`コンポーネントに追加
- Refactor: `ToastClose`コンポーネントの削除と`THEME_GENERATED_COUNT_LIMIT`のインポート位置変更
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->