### PR TITLE
Feature/#20 add input theme page

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -22,7 +22,7 @@ jobs:
           review_simple_changes: false
           review_comment_lgtm: false
           openai_light_model: gpt-3.5-turbo # 要約用モデル
-          openai_heavy_model: gpt-3.5-turbo # レビュー用モデル
+          openai_heavy_model: gpt-4 # レビュー用モデル
           openai_timeout_ms: 900000 # 15分
           language: ja-JP
           path_filters: |

--- a/front/package.json
+++ b/front/package.json
@@ -34,7 +34,8 @@
     "react-ztext": "^1.0.3",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^14.1.0",

--- a/front/src/app/[uuid]/input-theme/page.tsx
+++ b/front/src/app/[uuid]/input-theme/page.tsx
@@ -1,0 +1,8 @@
+import InputThemePresentation from "@/app/presentation/InputTheme/InputThemePresentation";
+import { getIdeaSessionInProgress } from "@/lib/idea-sessions";
+
+export default async function InputTheme() {
+  const ideaSession = await getIdeaSessionInProgress();
+
+  return <InputThemePresentation ideaSession={ideaSession} />;
+}

--- a/front/src/app/auth/signin/Signin.module.scss
+++ b/front/src/app/auth/signin/Signin.module.scss
@@ -1,5 +1,4 @@
 .container {
-  background-color: var(--black);
   display: grid;
   place-items: center;
   width: 100%;

--- a/front/src/app/auth/signin/Signin.module.scss
+++ b/front/src/app/auth/signin/Signin.module.scss
@@ -3,7 +3,9 @@
   display: grid;
   place-items: center;
   width: 100%;
-  height: 100%;
+  height: calc(100vh - var(--header-height));
+  position: relative;
+  z-index: 10;
 }
 
 .window {
@@ -37,6 +39,9 @@
 .description {
   font-size: 10px;
   color: var(--black);
+  a {
+    text-decoration: underline;
+  }
 
   @media (min-width: 768px) {
     font-size: 12px;

--- a/front/src/app/globals.scss
+++ b/front/src/app/globals.scss
@@ -82,6 +82,7 @@
   --light-blue: #4ac7d1;
   --pink: #fc6eb3;
   --purple: #6a00b7;
+  --red: #d5264c;
 
   --header-height: 88px;
   --page-padding: 24px;

--- a/front/src/app/globals.scss
+++ b/front/src/app/globals.scss
@@ -86,6 +86,7 @@
   --header-height: 88px;
   --page-padding: 24px;
   --page-padding-lg: 80px;
+  --back-button-length: 48px;
 }
 
 html,

--- a/front/src/app/presentation/CheckTheme/CheckThemePresentation.module.scss
+++ b/front/src/app/presentation/CheckTheme/CheckThemePresentation.module.scss
@@ -4,7 +4,7 @@
   position: relative;
   display: flex;
   justify-content: center;
-  align-items: start;
+  align-items: flex-start;
 }
 
 .container {

--- a/front/src/app/presentation/CheckTheme/CheckThemePresentation.module.scss
+++ b/front/src/app/presentation/CheckTheme/CheckThemePresentation.module.scss
@@ -1,14 +1,10 @@
-/* 変数 */
-$back-button-length: 56px;
-$back-button-length-lg: 96px;
-
 .wrapper {
-  height: calc(100vh - var(--header-height));
+  min-height: calc(100vh - var(--header-height));
   width: 100vw;
   position: relative;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: start;
 }
 
 .container {
@@ -17,11 +13,16 @@ $back-button-length-lg: 96px;
   justify-content: flex-start;
   align-items: center;
   gap: 60px;
-  height: calc(100% - $back-button-length - var(--page-padding));
+  height: calc(100% - var(--back-button-length) - var(--page-padding));
   width: calc(100% - var(--page-padding) * 2);
+  padding-bottom: calc(var(--back-button-length) + var(--page-padding) + 80px);
 
   @media screen and (min-width: 1024px) {
-    height: calc(100% - $back-button-length-lg - var(--page-padding-lg));
+    height: calc(100% - var(--back-button-length) - var(--page-padding-lg));
+    width: calc(100% - var(--page-padding-lg) * 2);
+    padding-bottom: calc(
+      var(--back-button-length) + var(--page-padding-lg) + 160px
+    );
   }
 }
 
@@ -45,12 +46,15 @@ $back-button-length-lg: 96px;
 .question {
   text-align: center;
   font-size: 18px;
+  margin-top: 48px;
 
   @media screen and (min-width: 1024px) {
     font-size: 24px;
+    margin-top: 64px;
   }
 }
 
+/* 戻るボタン */
 .back {
   position: absolute;
   bottom: var(--page-padding);

--- a/front/src/app/presentation/CheckTheme/CheckThemePresentation.module.scss
+++ b/front/src/app/presentation/CheckTheme/CheckThemePresentation.module.scss
@@ -61,3 +61,11 @@ $back-button-length-lg: 96px;
     left: var(--page-padding-lg);
   }
 }
+
+.arrow {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  margin-left: 0.75rem;
+}

--- a/front/src/app/presentation/CheckTheme/CheckThemePresentation.tsx
+++ b/front/src/app/presentation/CheckTheme/CheckThemePresentation.tsx
@@ -3,11 +3,11 @@
 import styles from "@/app/presentation/CheckTheme/CheckThemePresentation.module.scss";
 import Button from "@/components/elements/Button/Button";
 import { BackButton } from "@/components/ui/tailwind-buttons";
+import { useUUIDCheck } from "@/hooks/useUUIDCheck";
 import { updateIdeaSession } from "@/lib/idea-sessions";
 import { IdeaSessionType } from "@/types";
 import Error from "next/error";
-import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { IoChevronBack } from "react-icons/io5";
 
 export default function CheckThemePresentation({
@@ -16,37 +16,13 @@ export default function CheckThemePresentation({
   ideaSession: IdeaSessionType | null;
 }) {
   const router = useRouter();
-  const [statusCode, setStatusCode] = useState<number | null>(null);
-
-  // セッションは開始されており、ideaSessionは必ず取得できる想定なので
-  // nullの場合は、500エラーを返す
-  if (ideaSession === null) {
-    setStatusCode(500);
-  }
-
-  // ideaSessionからUUIDを取得
-  const uuid = ideaSession?.uuid;
-  // URLからUUIDを取得
-  const uuidFromPath = usePathname().split("/")[1];
-
-  useEffect(() => {
-    // URLに含まれるUUIDがログインユーザーのものと一致するかチェック
-    if (!uuid || !uuidFromPath || uuid !== uuidFromPath) {
-      setStatusCode(404);
-    } else {
-      setStatusCode(null);
-      // 遷移先パスをprefetch
-      router.prefetch(`/select-mode`);
-      router.prefetch(`/${uuid}/theme`);
-      router.prefetch(`/${uuid}/select-theme-category`);
-    }
-  }, [uuid, uuidFromPath]);
+  const { uuid, statusCode } = useUUIDCheck({ ideaSession });
 
   const handleYesClick = async () => {
     await updateIdeaSession(uuid as string, {
       isThemeDetermined: true,
     });
-    router.push(`/${uuid}/theme`);
+    router.push(`/${uuid}/input-theme`);
   };
 
   const handleNoClick = async () => {
@@ -90,7 +66,9 @@ export default function CheckThemePresentation({
       </div>
       <div className={styles.back}>
         <IoChevronBack className={styles.arrow} />
-        <BackButton onClick={handleBack}>BACK</BackButton>
+        <BackButton onClick={handleBack} type="button">
+          BACK
+        </BackButton>
       </div>
     </main>
   );

--- a/front/src/app/presentation/CheckTheme/CheckThemePresentation.tsx
+++ b/front/src/app/presentation/CheckTheme/CheckThemePresentation.tsx
@@ -8,6 +8,7 @@ import { IdeaSessionType } from "@/types";
 import Error from "next/error";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import { IoChevronBack } from "react-icons/io5";
 
 export default function CheckThemePresentation({
   ideaSession,
@@ -88,6 +89,7 @@ export default function CheckThemePresentation({
         </div>
       </div>
       <div className={styles.back}>
+        <IoChevronBack className={styles.arrow} />
         <BackButton onClick={handleBack}>BACK</BackButton>
       </div>
     </main>

--- a/front/src/app/presentation/InputTheme/InputThemePresentation.module.scss
+++ b/front/src/app/presentation/InputTheme/InputThemePresentation.module.scss
@@ -4,7 +4,7 @@
   position: relative;
   display: flex;
   justify-content: center;
-  align-items: start;
+  align-items: flex-start;
 }
 
 .container {

--- a/front/src/app/presentation/InputTheme/InputThemePresentation.module.scss
+++ b/front/src/app/presentation/InputTheme/InputThemePresentation.module.scss
@@ -59,6 +59,12 @@
   margin-top: 16px;
 }
 
+.error {
+  color: var(--red);
+  font-size: 16px;
+  margin: 8px 0 4px;
+}
+
 /* テキストエリア */
 .textareaContainer {
   width: 100%;

--- a/front/src/app/presentation/InputTheme/InputThemePresentation.module.scss
+++ b/front/src/app/presentation/InputTheme/InputThemePresentation.module.scss
@@ -1,0 +1,156 @@
+.wrapper {
+  min-height: calc(100vh - var(--header-height));
+  width: 100vw;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: start;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  height: calc(100% - var(--back-button-length) - var(--page-padding));
+  width: calc(100% - var(--page-padding) * 2);
+  padding-bottom: calc(var(--back-button-length) + var(--page-padding) + 80px);
+
+  @media screen and (min-width: 1024px) {
+    height: calc(100% - var(--back-button-length) - var(--page-padding-lg));
+    width: calc(100% - var(--page-padding-lg) * 2);
+    padding-bottom: calc(
+      var(--back-button-length) + var(--page-padding-lg) + 160px
+    );
+  }
+}
+
+.content {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  @media screen and (min-width: 768px) {
+    width: 50%;
+  }
+}
+
+/* 指示文 */
+.instruction {
+  text-align: center;
+  font-size: 18px;
+  margin-top: 48px;
+
+  @media screen and (min-width: 1024px) {
+    font-size: 24px;
+    margin-top: 64px;
+  }
+}
+
+/* フォーム */
+.form {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  margin-top: 16px;
+}
+
+/* テキストエリア */
+.textareaContainer {
+  width: 100%;
+  position: relative;
+}
+
+.textarea {
+  height: 6rem;
+
+  @media screen and (min-width: 768px) {
+    height: 8rem;
+  }
+}
+
+.microphone {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  color: var(--black);
+  width: 20px;
+  height: 20px;
+}
+
+/* チェック事項説明 */
+.checkItem {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  font-size: 18px;
+  margin-top: 40px;
+
+  @media screen and (min-width: 1024px) {
+    font-size: 24px;
+  }
+}
+
+.checkContainer {
+  padding: 24px;
+  border: 1px solid var(--white);
+  border-radius: 8px;
+  background-color: var(--white);
+  margin-top: 8px;
+  margin-bottom: 40px;
+}
+
+.checkExamples {
+  color: var(--black);
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  grid-template-rows: repeat(3, 1fr);
+  align-items: center;
+  gap: 16px;
+}
+
+.checkDecoration {
+  text-align: center;
+  border: solid 1px var(--black);
+  color: var(--white);
+  background-color: var(--black);
+  border-radius: 20px;
+  width: 120px;
+  height: 40px;
+  font-size: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
+.checkExample {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+/* 戻るボタン */
+.back {
+  position: absolute;
+  bottom: var(--page-padding);
+  left: var(--page-padding);
+
+  @media screen and (min-width: 1024px) {
+    bottom: var(--page-padding-lg);
+    left: var(--page-padding-lg);
+  }
+}
+
+.arrow {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  margin-left: 0.75rem;
+}

--- a/front/src/app/presentation/InputTheme/InputThemePresentation.text.tsx
+++ b/front/src/app/presentation/InputTheme/InputThemePresentation.text.tsx
@@ -1,0 +1,47 @@
+import CheckThemePresentation from "@/app/presentation/InputTheme/InputThemePresentation";
+import { render, screen } from "@testing-library/react";
+
+const ideaSession = {
+  uuid: "uuid",
+};
+
+describe("InputThemePresentation", () => {
+  it("should render the instruction correctly", () => {
+    render(<CheckThemePresentation ideaSession={ideaSession} />);
+
+    expect(
+      screen.getByRole("paragraph", {
+        name: "アイデア出しのテーマを入力してね",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("should display the textarea", () => {
+    render(<CheckThemePresentation ideaSession={ideaSession} />);
+
+    expect(screen.getByRole("textbox", { name: "theme" })).toBeInTheDocument();
+  });
+
+  it("should render the checkItem correctly", () => {
+    render(<CheckThemePresentation ideaSession={ideaSession} />);
+
+    expect(
+      screen.getByRole("paragraph", {
+        name: "テーマが具体的かどうかチェック",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("check")).toBeInTheDocument();
+  });
+
+  it("should display the submit button", () => {
+    render(<CheckThemePresentation ideaSession={ideaSession} />);
+
+    expect(screen.getByRole("button", { name: "決定" })).toBeInTheDocument();
+  });
+
+  it("should display the BackButton", () => {
+    render(<CheckThemePresentation ideaSession={ideaSession} />);
+
+    expect(screen.getByText("BACK")).toBeInTheDocument();
+  });
+});

--- a/front/src/app/presentation/InputTheme/InputThemePresentation.tsx
+++ b/front/src/app/presentation/InputTheme/InputThemePresentation.tsx
@@ -95,7 +95,7 @@ export default function InputThemePresentation({
                 </div>
               </div>
             </div>
-            <input type="hidden" value={uuid} />
+            <input type="hidden" value={uuid} id="uuid" name="uuid" />
             <LitUpBorders type="submit">決定</LitUpBorders>
           </form>
         </div>

--- a/front/src/app/presentation/InputTheme/InputThemePresentation.tsx
+++ b/front/src/app/presentation/InputTheme/InputThemePresentation.tsx
@@ -66,7 +66,7 @@ export default function InputThemePresentation({
               <IoCheckboxOutline />
               テーマが具体的かどうかチェック
             </p>
-            <div className={styles.checkContainer}>
+            <div className={styles.checkContainer} data-testid="check">
               <div className={styles.checkExamples}>
                 <div>
                   <div className={styles.checkDecoration}>

--- a/front/src/app/presentation/InputTheme/InputThemePresentation.tsx
+++ b/front/src/app/presentation/InputTheme/InputThemePresentation.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import styles from "@/app/presentation/InputTheme/InputThemePresentation.module.scss";
+import { BackButton, LitUpBorders } from "@/components/ui/tailwind-buttons";
+import { Textarea } from "@/components/ui/textarea";
+import { useUUIDCheck } from "@/hooks/useUUIDCheck";
+import { State, submitTheme } from "@/lib/actions";
+import { IdeaSessionType } from "@/types";
+import Error from "next/error";
+import { useRouter } from "next/navigation";
+import { useFormState } from "react-dom";
+import { FaMicrophone } from "react-icons/fa";
+import {
+  FaRegFaceFrown,
+  FaRegFaceGrin,
+  FaRegFaceGrinBeam,
+} from "react-icons/fa6";
+import { IoCheckboxOutline, IoChevronBack } from "react-icons/io5";
+
+export default function InputThemePresentation({
+  ideaSession,
+}: {
+  ideaSession: IdeaSessionType | null;
+}) {
+  const router = useRouter();
+  const { uuid, statusCode } = useUUIDCheck({ ideaSession });
+
+  // フォーム送信時の処理
+  const initialState: State = {
+    errors: {},
+  };
+  const [state, dispatch] = useFormState(submitTheme, initialState);
+
+  // 戻るボタンの処理
+  const handleBack = () => {
+    router.push(`/${uuid}/check-theme`);
+  };
+
+  // エラーがある場合はエラーページを表示
+  if (statusCode) {
+    return <Error statusCode={statusCode} />;
+  }
+
+  return (
+    <main className={styles.wrapper}>
+      <div className={styles.container}>
+        <div className={styles.content}>
+          <p className={styles.instruction}>アイデア出しのテーマを入力してね</p>
+          <form action={dispatch} className={styles.form}>
+            {state?.errors?.theme &&
+              state?.errors?.theme.map((error, index) => (
+                <div key={index} id="theme-error" className={styles.error}>
+                  {error}
+                </div>
+              ))}
+            <div className={styles.textareaContainer}>
+              <Textarea
+                id="theme"
+                name="theme"
+                aria-describedby="theme-error"
+                className={styles.textarea}
+              />
+              <FaMicrophone className={styles.microphone} />
+            </div>
+            <p className={styles.checkItem}>
+              <IoCheckboxOutline />
+              テーマが具体的かどうかチェック
+            </p>
+            <div className={styles.checkContainer}>
+              <div className={styles.checkExamples}>
+                <div>
+                  <div className={styles.checkDecoration}>
+                    NG
+                    <FaRegFaceFrown />
+                  </div>
+                </div>
+                <div className={styles.checkExample}>アプリ案</div>
+                <div>
+                  <div className={styles.checkDecoration}>
+                    OK
+                    <FaRegFaceGrin />
+                  </div>
+                </div>
+                <div className={styles.checkExample}>
+                  プログラミング学習アプリ
+                </div>
+                <div>
+                  <div className={styles.checkDecoration}>
+                    BEST
+                    <FaRegFaceGrinBeam />
+                  </div>
+                </div>
+                <div className={styles.checkExample}>
+                  子どもが楽しく学べるプログラミング学習アプリ
+                </div>
+              </div>
+            </div>
+            <input type="hidden" value={uuid} />
+            <LitUpBorders type="submit">決定</LitUpBorders>
+          </form>
+        </div>
+      </div>
+      <div className={styles.back}>
+        <IoChevronBack className={styles.arrow} />
+        <BackButton onClick={handleBack} type="button">
+          BACK
+        </BackButton>
+      </div>
+    </main>
+  );
+}

--- a/front/src/app/presentation/SelectMode/SelectModePresentation.tsx
+++ b/front/src/app/presentation/SelectMode/SelectModePresentation.tsx
@@ -31,19 +31,19 @@ export function SelectModePresentation() {
   // 途中セッションの中断時のパスを判定
   const checkPath = (ideaSession: IdeaSessionType) => {
     if (ideaSession.isAiAnswerGenerated) {
-      return "idea-generation"; // アイデア出し画面（回答生成後）
+      return "generate-ideas"; // アイデア出し画面（回答生成後）
     }
 
     if (ideaSession.theme) {
-      return "idea-generation"; // アイデア出し画面（回答生成前）
+      return "generate-ideas"; // アイデア出し画面（回答生成前）
     }
 
     if (ideaSession.isThemeDetermined) {
-      return "theme"; // テーマ入力画面
+      return "input-theme"; // テーマ入力画面
     }
 
     if (ideaSession.isAiThemeGenerated) {
-      return "theme-generation"; // テーマ生成画面
+      return "generate-theme"; // テーマ生成画面
     }
 
     if (ideaSession.category !== 0) {

--- a/front/src/components/layouts/Header/Header.module.scss
+++ b/front/src/components/layouts/Header/Header.module.scss
@@ -5,7 +5,6 @@
   padding: 16px 24px 0;
   height: var(--header-height);
   width: 100%;
-  z-index: 10;
 
   @media screen and (min-width: 1024px) {
     padding: 16px 80px 0;
@@ -17,7 +16,7 @@
   position: fixed;
   height: 72px;
   width: 112px;
-  z-index: 10;
+  z-index: 30;
 }
 
 .logo {
@@ -28,7 +27,7 @@
 /* Menuボタン */
 .hamburger {
   position: fixed;
-  z-index: 30;
+  z-index: 45;
   top: 16px;
   right: 24px;
   width: 56px;
@@ -37,6 +36,7 @@
   background-color: var(--white);
   opacity: 0.8;
   cursor: pointer;
+  margin-top: 8px;
 
   span {
     display: inline-block;
@@ -128,7 +128,7 @@
 
   &.active {
     opacity: 1;
-    z-index: 20;
+    z-index: 40;
   }
 }
 

--- a/front/src/components/layouts/Header/Header.tsx
+++ b/front/src/components/layouts/Header/Header.tsx
@@ -45,19 +45,19 @@ export default function Header() {
   // 途中セッションの中断時のパスを判定
   const checkPath = (ideaSession: IdeaSessionType) => {
     if (ideaSession.isAiAnswerGenerated) {
-      return "idea-generation"; // アイデア出し画面（回答生成後）
+      return "generate-ideas"; // アイデア出し画面（回答生成後）
     }
 
     if (ideaSession.theme) {
-      return "idea-generation"; // アイデア出し画面（回答生成前）
+      return "generate-ideas"; // アイデア出し画面（回答生成前）
     }
 
     if (ideaSession.isThemeDetermined) {
-      return "theme"; // テーマ入力画面
+      return "input-theme"; // テーマ入力画面
     }
 
     if (ideaSession.isAiThemeGenerated) {
-      return "theme-generation"; // テーマ生成画面
+      return "generate-theme"; // テーマ生成画面
     }
 
     if (ideaSession.category !== 0) {

--- a/front/src/components/ui/tailwind-buttons.tsx
+++ b/front/src/components/ui/tailwind-buttons.tsx
@@ -33,7 +33,7 @@ export function BorderMagic({ children, onClick }: TailwindButtonProps) {
 export function BackButton({ children, onClick }: TailwindButtonProps) {
   return (
     <button
-      className="shadow-[inset_0_0_0_2px_#616467] px-8 py-4 rounded-full tracking-widest uppercase font-normal text-xs bg-transparent hover:bg-[#616467] hover:text-white transition duration-200"
+      className="shadow-[inset_0_0_0_2px_#616467] px-12 py-4 rounded-full tracking-widest uppercase font-normal text-xs bg-transparent hover:bg-[#616467] hover:text-white transition duration-200"
       onClick={onClick}
     >
       {children}

--- a/front/src/components/ui/tailwind-buttons.tsx
+++ b/front/src/components/ui/tailwind-buttons.tsx
@@ -2,12 +2,13 @@
 
 type TailwindButtonProps = {
   children: React.ReactNode;
-  onClick: () => void;
+  onClick?: () => void;
+  type: "button" | "submit";
 };
 
-export function LitUpBorders({ children, onClick }: TailwindButtonProps) {
+export function LitUpBorders({ children, onClick, type }: TailwindButtonProps) {
   return (
-    <button className="p-[3px] relative" onClick={onClick}>
+    <button type={type} className="p-[3px] relative" onClick={onClick}>
       <div className="absolute inset-0 bg-gradient-to-r from-indigo-500 to-purple-500 rounded-lg" />
       <div className="px-8 py-2  bg-black rounded-[6px]  relative group transition duration-200 text-white hover:bg-transparent">
         {children}
@@ -16,9 +17,10 @@ export function LitUpBorders({ children, onClick }: TailwindButtonProps) {
   );
 }
 
-export function BorderMagic({ children, onClick }: TailwindButtonProps) {
+export function BorderMagic({ children, onClick, type }: TailwindButtonProps) {
   return (
     <button
+      type={type}
       className="relative inline-flex h-12 overflow-hidden rounded-full p-[1px] focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50"
       onClick={onClick}
     >
@@ -30,9 +32,10 @@ export function BorderMagic({ children, onClick }: TailwindButtonProps) {
   );
 }
 
-export function BackButton({ children, onClick }: TailwindButtonProps) {
+export function BackButton({ children, onClick, type }: TailwindButtonProps) {
   return (
     <button
+      type={type}
       className="shadow-[inset_0_0_0_2px_#616467] px-12 py-4 rounded-full tracking-widest uppercase font-normal text-xs bg-transparent hover:bg-[#616467] hover:text-white transition duration-200"
       onClick={onClick}
     >
@@ -41,9 +44,10 @@ export function BackButton({ children, onClick }: TailwindButtonProps) {
   );
 }
 
-export function Shimmer({ children, onClick }: TailwindButtonProps) {
+export function Shimmer({ children, onClick, type }: TailwindButtonProps) {
   return (
     <button
+      type={type}
       className="inline-flex h-12 animate-shimmer items-center justify-center rounded-md border border-slate-800 bg-[linear-gradient(110deg,#000103,45%,#1e2631,55%,#000103)] bg-[length:200%_100%] px-6 font-medium text-slate-400 transition-colors focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50"
       onClick={onClick}
     >
@@ -52,9 +56,10 @@ export function Shimmer({ children, onClick }: TailwindButtonProps) {
   );
 }
 
-export function Simle({ children, onClick }: TailwindButtonProps) {
+export function Simle({ children, onClick, type }: TailwindButtonProps) {
   return (
     <button
+      type={type}
       className="px-4 py-2 rounded-md border border-neutral-300 bg-neutral-100 text-neutral-500 text-sm hover:-translate-y-1 transform transition duration-200 hover:shadow-md"
       onClick={onClick}
     >

--- a/front/src/components/ui/textarea.tsx
+++ b/front/src/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-slate-900 ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/front/src/hooks/useUUIDCheck.tsx
+++ b/front/src/hooks/useUUIDCheck.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ *  UUIDがユーザーの所有するものがチェックするカスタムフック
+ *
+ *  正当なUUIDが取得できなければエラーコードをセットする
+ */
+import { IdeaSessionType } from "@/types";
+
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+export const useUUIDCheck = ({
+  ideaSession,
+}: {
+  ideaSession: IdeaSessionType | null;
+}) => {
+  const router = useRouter();
+  const [statusCode, setStatusCode] = useState<number | null>(null);
+
+  // セッションは開始されており、ideaSessionは必ず取得できる想定なので
+  // nullの場合は、500エラーを返す
+  if (ideaSession === null) {
+    setStatusCode(500);
+  }
+
+  // ideaSessionからUUIDを取得
+  const uuid = ideaSession?.uuid;
+  // URLからUUIDを取得
+  const uuidFromPath = usePathname().split("/")[1];
+
+  useEffect(() => {
+    // URLに含まれるUUIDがログインユーザーのものと一致するかチェック
+    if (!uuid || !uuidFromPath || uuid !== uuidFromPath) {
+      setStatusCode(404);
+    } else {
+      setStatusCode(null);
+      // 遷移先パスをprefetch
+      router.prefetch(`/select-mode`);
+      router.prefetch(`/${uuid}/input-theme`);
+      router.prefetch(`/${uuid}/select-theme-category`);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { uuid, statusCode };
+};

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -1,9 +1,9 @@
 "use server";
 
+import { updateIdeaSession } from "@/lib/idea-sessions";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { z } from "zod";
-import { updateIdeaSession } from "./idea-sessions";
 
 export type State = {
   errors?: {
@@ -12,7 +12,7 @@ export type State = {
 };
 
 const ThemeSchema = z.object({
-  theme: z.string().trim().min(1, { message: "テーマを入力してください" }),
+  theme: z.string().trim().min(1, { message: "Error: テーマの入力は必須だよ" }),
   uuid: z.string(), // uuidはhiddenで自動的に送信されるため、厳密なバリデーションは不要
 });
 
@@ -23,11 +23,13 @@ export const submitTheme = async (prevState: State, formData: FormData) => {
     uuid: formData.get("uuid"),
   });
 
+  console.log(!validatedTheme.success);
   // バリデーション失敗なら、エラーメッセージを返す
   if (!validatedTheme.success) {
     const errors = {
       errors: validatedTheme.error.flatten().fieldErrors,
     };
+    console.log("errors");
     return errors;
   }
 

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { z } from "zod";
+import { updateIdeaSession } from "./idea-sessions";
+
+export type State = {
+  errors?: {
+    theme?: string[];
+  };
+};
+
+const ThemeSchema = z.object({
+  theme: z.string().trim().min(1, { message: "テーマを入力してください" }),
+  uuid: z.string(), // uuidはhiddenで自動的に送信されるため、厳密なバリデーションは不要
+});
+
+export const submitTheme = async (prevState: State, formData: FormData) => {
+  // ThemeSchemaによるバリデーション
+  const validatedTheme = ThemeSchema.safeParse({
+    theme: formData.get("theme"),
+    uuid: formData.get("uuid"),
+  });
+
+  // バリデーション失敗なら、エラーメッセージを返す
+  if (!validatedTheme.success) {
+    const errors = {
+      errors: validatedTheme.error.flatten().fieldErrors,
+    };
+    return errors;
+  }
+
+  const { theme, uuid } = validatedTheme.data;
+
+  // idea_sessionテーブルのthemeカラムを更新
+  updateIdeaSession(uuid, { theme });
+
+  revalidatePath(`${uuid}/generate-ideas`);
+  redirect(`${uuid}/generate-ideas`);
+};

--- a/front/src/lib/ai-usage-history.ts
+++ b/front/src/lib/ai-usage-history.ts
@@ -1,8 +1,8 @@
 "use server";
 
+import { authOptions } from "@/lib/options";
 import { Deserializer } from "jsonapi-serializer";
 import { getServerSession } from "next-auth";
-import { authOptions } from "./options";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -2690,6 +2690,17 @@ array.prototype.filter@^1.0.3:
     es-array-method-boxes-properly "^1.0.0"
     is-string "^1.0.7"
 
+array.prototype.findlast@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.findlast/-/array.prototype.findlast-1.2.4.tgz#eeb9e45fc894055c82e5675c463e8077b827ad36"
+  integrity sha512-BMtLxpV+8BD+6ZPFIWmnUBpQoy+A+ujcg4rhp2iwCRJYA7PEh2MS4NL3lz8EiDlLrJPp2hg9qWihr5pd//jcGw==
+  dependencies:
+    call-bind "^1.0.5"
+    define-properties "^1.2.1"
+    es-abstract "^1.22.3"
+    es-errors "^1.3.0"
+    es-shim-unscopables "^1.0.2"
+
 array.prototype.findlastindex@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.4.tgz#d1c50f0b3a9da191981ff8942a0aedd82794404f"
@@ -2711,7 +2722,7 @@ array.prototype.flat@^1.3.1, array.prototype.flat@^1.3.2:
     es-abstract "^1.22.1"
     es-shim-unscopables "^1.0.0"
 
-array.prototype.flatmap@^1.3.1, array.prototype.flatmap@^1.3.2:
+array.prototype.flatmap@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz#c9a7c6831db8e719d6ce639190146c24bbd3e527"
   integrity sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==
@@ -2721,7 +2732,17 @@ array.prototype.flatmap@^1.3.1, array.prototype.flatmap@^1.3.2:
     es-abstract "^1.22.1"
     es-shim-unscopables "^1.0.0"
 
-array.prototype.tosorted@^1.1.1:
+array.prototype.toreversed@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/array.prototype.toreversed/-/array.prototype.toreversed-1.1.2.tgz#b989a6bf35c4c5051e1dc0325151bf8088954eba"
+  integrity sha512-wwDCoT4Ck4Cz7sLtgUmzR5UV3YF5mFHUlbChCzZBQZ+0m2cl/DH3tKgvphv1nKgFsJ48oCSg6p91q2Vm0I/ZMA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
+    es-shim-unscopables "^1.0.0"
+
+array.prototype.tosorted@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/array.prototype.tosorted/-/array.prototype.tosorted-1.1.3.tgz#c8c89348337e51b8a3c48a9227f9ce93ceedcba8"
   integrity sha512-/DdH4TiTmOKzyQbp/eadcCVexiCb36xJg7HshYOYJnNZFDj33GEv0P7GxsynpShhq4OLYJzbGcBDkLsDt7MnNg==
@@ -2999,9 +3020,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
-  version "1.0.30001591"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001591.tgz#16745e50263edc9f395895a7cd468b9f3767cf33"
-  integrity sha512-PCzRMei/vXjJyL5mJtzNiUCKP59dm8Apqc3PH8gJkMnMXZGox93RbE76jHsmLwmIo6/3nsYIpJtx0O7u5PqFuQ==
+  version "1.0.30001593"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001593.tgz#7cda1d9e5b0cad6ebab4133b1f239d4ea44fe659"
+  integrity sha512-UWM1zlo3cZfkpBysd7AS+z+v007q9G1+fLTUU42rQnY6t2axoogPW/xol6T7juU5EUoOhML4WgBIdG+9yYqAjQ==
 
 chalk@^2.4.2:
   version "2.4.2"
@@ -3624,7 +3645,7 @@ es-get-iterator@^1.1.3:
     isarray "^2.0.5"
     stop-iteration-iterator "^1.0.0"
 
-es-iterator-helpers@^1.0.12, es-iterator-helpers@^1.0.15:
+es-iterator-helpers@^1.0.15, es-iterator-helpers@^1.0.17:
   version "1.0.17"
   resolved "https://registry.yarnpkg.com/es-iterator-helpers/-/es-iterator-helpers-1.0.17.tgz#123d1315780df15b34eb181022da43e734388bb8"
   integrity sha512-lh7BsUqelv4KUbR5a/ZTaGGIMLCjPGPqJ6q+Oq24YP0RdyptX1uzm4vvaqzk7Zx3bpl/76YLTTDj9L7uYQ92oQ==
@@ -3801,26 +3822,28 @@ eslint-plugin-jsx-a11y@^6.7.1:
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
 eslint-plugin-react@^7.33.2:
-  version "7.33.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz#69ee09443ffc583927eafe86ffebb470ee737608"
-  integrity sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==
+  version "7.34.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.34.0.tgz#ab71484d54fc409c37025c5eca00eb4177a5e88c"
+  integrity sha512-MeVXdReleBTdkz/bvcQMSnCXGi+c9kvy51IpinjnJgutl3YTHWsDdke7Z1ufZpGfDG8xduBDKyjtB9JH1eBKIQ==
   dependencies:
-    array-includes "^3.1.6"
-    array.prototype.flatmap "^1.3.1"
-    array.prototype.tosorted "^1.1.1"
+    array-includes "^3.1.7"
+    array.prototype.findlast "^1.2.4"
+    array.prototype.flatmap "^1.3.2"
+    array.prototype.toreversed "^1.1.2"
+    array.prototype.tosorted "^1.1.3"
     doctrine "^2.1.0"
-    es-iterator-helpers "^1.0.12"
+    es-iterator-helpers "^1.0.17"
     estraverse "^5.3.0"
     jsx-ast-utils "^2.4.1 || ^3.0.0"
     minimatch "^3.1.2"
-    object.entries "^1.1.6"
-    object.fromentries "^2.0.6"
-    object.hasown "^1.1.2"
-    object.values "^1.1.6"
+    object.entries "^1.1.7"
+    object.fromentries "^2.0.7"
+    object.hasown "^1.1.3"
+    object.values "^1.1.7"
     prop-types "^15.8.1"
-    resolve "^2.0.0-next.4"
+    resolve "^2.0.0-next.5"
     semver "^6.3.1"
-    string.prototype.matchall "^4.0.8"
+    string.prototype.matchall "^4.0.10"
 
 eslint-plugin-unused-imports@^3.0.0:
   version "3.1.0"
@@ -5594,7 +5617,7 @@ object.assign@^4.1.4, object.assign@^4.1.5:
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
-object.entries@^1.1.6, object.entries@^1.1.7:
+object.entries@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.7.tgz#2b47760e2a2e3a752f39dd874655c61a7f03c131"
   integrity sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==
@@ -5603,7 +5626,7 @@ object.entries@^1.1.6, object.entries@^1.1.7:
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
 
-object.fromentries@^2.0.6, object.fromentries@^2.0.7:
+object.fromentries@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.7.tgz#71e95f441e9a0ea6baf682ecaaf37fa2a8d7e616"
   integrity sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==
@@ -5623,7 +5646,7 @@ object.groupby@^1.0.1:
     es-abstract "^1.22.3"
     es-errors "^1.0.0"
 
-object.hasown@^1.1.2:
+object.hasown@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/object.hasown/-/object.hasown-1.1.3.tgz#6a5f2897bb4d3668b8e79364f98ccf971bda55ae"
   integrity sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==
@@ -6176,7 +6199,7 @@ resolve@^1.1.7, resolve@^1.14.2, resolve@^1.20.0, resolve@^1.22.2, resolve@^1.22
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-resolve@^2.0.0-next.4:
+resolve@^2.0.0-next.5:
   version "2.0.0-next.5"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.5.tgz#6b0ec3107e671e52b68cd068ef327173b90dc03c"
   integrity sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==
@@ -6417,7 +6440,7 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-string.prototype.matchall@^4.0.8:
+string.prototype.matchall@^4.0.10:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz#a1553eb532221d4180c51581d6072cd65d1ee100"
   integrity sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==
@@ -7149,3 +7172,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.22.4:
+  version "3.22.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==


### PR DESCRIPTION
## issue番号
close #20

## やったこと
- [x]  レイアウト追加
- [x] ユーザーが入力したテーマをDBに保存できるよう設定
- [x] テーマ有無確認画面から遷移できるようにする

## やらないこと
音声入力機能（#103で対応）

## できるようになること（ユーザ目線）
アイデア出しのテーマを入力できるようになります。

## できなくなること（ユーザ目線）
なし

## 動作確認
- 未入力のまま送信するとエラーが表示されることを確認
- 送信したテーマがDBに保存されていることを確認
- 送信後、アイデア出し画面に遷移することを確認

## その他
なし

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- New Feature: 新しいテーマ入力フォームとそのバリデーション機能が追加されました
- New Feature: UUIDチェックのカスタムフック`useUUIDCheck`を導入しました
- Refactor: `.github/workflows/code_review.yml`で使用するOpenAIモデルを`gpt-4`に更新しました
- Style: 複数のCSSクラスとコンポーネントのスタイルを調整しました
- Chore: `zod`パッケージをプロジェクトに追加しました
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->