### PR TITLE
fix: config.action_cable.urlを修正 #113

### DIFF
--- a/back/config/environments/production.rb
+++ b/back/config/environments/production.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
-  config.action_cable.url = 'wss://idea-space-trip.net:3000/cable'
+  config.action_cable.url = 'wss://idea-space-trip.fly.dev/cable'
 
   config.action_cable.allowed_request_origins = [%r{https://idea-space-trip\.*}]
 


### PR DESCRIPTION
## issue番号
#113

## やったこと
- production.rbの config.action_cable.url = 'wss://idea-space-trip.net:3000/cable'において、idea-space-trip.netではなく、idea-space-trip.fly.devを指定に修正
- 3000ポート指定を削除

## やらないこと
なし

## できるようになること（ユーザ目線）
ActionCableによってAIから回答が生成されると表示されるようになる。

## できなくなること（ユーザ目線）
なし

## 動作確認
デプロイ後確認

## その他
なし
