### PR TITLE
Feature/#25 add idea memo index page

### DIFF
--- a/back/app/controllers/api/v1/idea_memos_controller.rb
+++ b/back/app/controllers/api/v1/idea_memos_controller.rb
@@ -1,7 +1,17 @@
 module Api
   module V1
     class IdeaMemosController < ApplicationController
-      def index; end
+      def index
+        idea_memos = policy_scope(@current_user.idea_memos.includes(:idea_session))
+
+        if idea_memos.empty?
+          render json: nil, status: :ok
+        else
+          render json: IdeaMemoSerializer.new(idea_memos, include: [:idea_session])
+                                         .serializable_hash.to_json,
+                 status: :ok
+        end
+      end
 
       def show; end
 

--- a/back/app/serializers/idea_memo_serializer.rb
+++ b/back/app/serializers/idea_memo_serializer.rb
@@ -16,6 +16,6 @@ class IdeaMemoSerializer
   set_key_transform :camel_lower
 
   set_type :idea_memo
-  attributes :perspective, :hint, :answer, :comment, :idea_session_id
+  attributes :perspective, :hint, :answer, :comment, :idea_session_id, :created_at
   belongs_to :idea_session, serializer: IdeaSessionSerializer
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
         get 'idea_memos/all_in_session', to: 'idea_memos#all_in_session'
       end
       resource :ai_usage_history, only: %i[show update]
-      resources :idea_memos, only: %i[index show edit update destroy] do
+      resources :idea_memos, param: :uuid, only: %i[index show edit update destroy] do
         collection do
           get 'this_month_count', to: 'idea_memos#this_month_count'
         end

--- a/back/db/migrate/20240316021820_create_idea_memos.rb
+++ b/back/db/migrate/20240316021820_create_idea_memos.rb
@@ -1,6 +1,7 @@
 class CreateIdeaMemos < ActiveRecord::Migration[7.1]
   def change
     create_table :idea_memos do |t|
+      t.string :uuid, null: false, default: -> { '(uuid())' }
       t.references :idea_session, null: false, foreign_key: true
       t.integer :perspective, null: false
       t.text :hint
@@ -9,5 +10,6 @@ class CreateIdeaMemos < ActiveRecord::Migration[7.1]
 
       t.timestamps
     end
+    add_index :idea_memos, :uuid, unique: true
   end
 end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -39,6 +39,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_16_021820) do
   end
 
   create_table "idea_memos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "uuid", default: -> { "(uuid())" }, null: false
     t.bigint "idea_session_id", null: false
     t.integer "perspective", null: false
     t.text "hint"
@@ -47,6 +48,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_16_021820) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["idea_session_id"], name: "index_idea_memos_on_idea_session_id"
+    t.index ["uuid"], name: "index_idea_memos_on_uuid", unique: true
   end
 
   create_table "idea_sessions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/front/src/app/idea-memos/page.tsx
+++ b/front/src/app/idea-memos/page.tsx
@@ -1,0 +1,9 @@
+import IdeaMemosPresentation from "@/app/presentation/IdeaMemos/IdeaMemosPresentation";
+import { getAllIdeaSessionsWithMemos } from "@/lib/idea-memos";
+import { IdeaMemoType } from "@/types";
+
+export default async function page() {
+  const ideaMemos: IdeaMemoType[] = await getAllIdeaSessionsWithMemos();
+
+  return <IdeaMemosPresentation ideaMemos={ideaMemos} />;
+}

--- a/front/src/app/idea-memos/page.tsx
+++ b/front/src/app/idea-memos/page.tsx
@@ -1,9 +1,9 @@
 import IdeaMemosPresentation from "@/app/presentation/IdeaMemos/IdeaMemosPresentation";
-import { getAllIdeaSessionsWithMemos } from "@/lib/idea-memos";
+import { getAllIdeaMemos } from "@/lib/idea-memos";
 import { IdeaMemoType } from "@/types";
 
 export default async function page() {
-  const ideaMemos: IdeaMemoType[] = await getAllIdeaSessionsWithMemos();
+  const ideaMemos: IdeaMemoType[] = await getAllIdeaMemos();
 
   return <IdeaMemosPresentation ideaMemos={ideaMemos} />;
 }

--- a/front/src/app/presentation/GenerateIdeas/GenerateIdeasPresentation.tsx
+++ b/front/src/app/presentation/GenerateIdeas/GenerateIdeasPresentation.tsx
@@ -314,9 +314,11 @@ export default function GenerateIdeasPresentation({
                   <Blob className={styles.blob} />
                 </div>
               </div>
-              <BorderMagic type="button" onClick={handleShowAnswers}>
-                AIの回答を見る
-              </BorderMagic>
+              {!isOpenAIAnswer && (
+                <BorderMagic type="button" onClick={handleShowAnswers}>
+                  AIの回答を見る
+                </BorderMagic>
+              )}
               {isOpenAIAnswer && (
                 <>
                   <div className={styles.aiAnswerContainer}>

--- a/front/src/app/presentation/IdeaMemos/IdeaMemosPresentation.module.scss
+++ b/front/src/app/presentation/IdeaMemos/IdeaMemosPresentation.module.scss
@@ -27,6 +27,7 @@
 
 .content {
   width: 100%;
+  height: 100%;
   display: grid;
   grid-template-columns: 1fr;
   gap: 24px;
@@ -36,4 +37,28 @@
     grid-template-columns: repeat(3, 1fr);
     gap: 16px;
   }
+}
+
+.noDataContainer {
+  height: calc(100vh - var(--back-button-length) - var(--page-padding));
+  width: 100%;
+  padding-bottom: calc(var(--back-button-length) + var(--page-padding) + 80px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  @media screen and (min-width: 1024px) {
+    height: calc(100vh - var(--back-button-length) - var(--page-padding-lg));
+    padding-bottom: calc(
+      var(--back-button-length) + var(--page-padding-lg) + 160px
+    );
+  }
+}
+
+.message {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/front/src/app/presentation/IdeaMemos/IdeaMemosPresentation.module.scss
+++ b/front/src/app/presentation/IdeaMemos/IdeaMemosPresentation.module.scss
@@ -1,0 +1,39 @@
+.wrapper {
+  min-height: calc(100vh - var(--header-height));
+  width: 100vw;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  height: calc(100% - var(--back-button-length) - var(--page-padding));
+  width: calc(100% - var(--page-padding) * 2);
+  padding-bottom: calc(var(--back-button-length) + var(--page-padding) + 80px);
+
+  @media screen and (min-width: 1024px) {
+    height: calc(100% - var(--back-button-length) - var(--page-padding-lg));
+    width: calc(100% - var(--page-padding-lg) * 2);
+    padding-bottom: calc(
+      var(--back-button-length) + var(--page-padding-lg) + 160px
+    );
+  }
+}
+
+.content {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+  padding-top: 48px;
+
+  @media screen and (min-width: 1280px) {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+  }
+}

--- a/front/src/app/presentation/IdeaMemos/IdeaMemosPresentation.tsx
+++ b/front/src/app/presentation/IdeaMemos/IdeaMemosPresentation.tsx
@@ -1,0 +1,27 @@
+import styles from "@/app/presentation/IdeaMemos/IdeaMemosPresentation.module.scss";
+import IdeaMemoCard from "@/components/elements/IdeaMemoCard/IdeaMemoCard";
+import { IdeaMemoType } from "@/types";
+
+export default function IdeaMemosPresentation({
+  ideaMemos,
+}: {
+  ideaMemos: IdeaMemoType[];
+}) {
+  return (
+    <main className={styles.wrapper}>
+      <div className={styles.container}>
+        <div className={styles.content}>
+          {ideaMemos.length === 0 ? (
+            <div>
+              <div>まだアイデアメモがないよ。</div>
+            </div>
+          ) : (
+            ideaMemos.map((memo) => (
+              <IdeaMemoCard key={memo.uuid} ideaMemo={memo} />
+            ))
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/front/src/app/presentation/IdeaMemos/IdeaMemosPresentation.tsx
+++ b/front/src/app/presentation/IdeaMemos/IdeaMemosPresentation.tsx
@@ -1,27 +1,47 @@
+"use client";
+
 import styles from "@/app/presentation/IdeaMemos/IdeaMemosPresentation.module.scss";
+import BackButton from "@/components/elements/BackButton/BackButton";
 import IdeaMemoCard from "@/components/elements/IdeaMemoCard/IdeaMemoCard";
 import { IdeaMemoType } from "@/types";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 export default function IdeaMemosPresentation({
   ideaMemos,
 }: {
   ideaMemos: IdeaMemoType[];
 }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.prefetch("select-mode");
+  }, []);
+
+  // 戻るボタンの処理
+  const handleBack = () => {
+    router.push("/select-mode");
+  };
+
   return (
     <main className={styles.wrapper}>
-      <div className={styles.container}>
-        <div className={styles.content}>
-          {ideaMemos.length === 0 ? (
-            <div>
-              <div>まだアイデアメモがないよ。</div>
-            </div>
-          ) : (
-            ideaMemos.map((memo) => (
-              <IdeaMemoCard key={memo.uuid} ideaMemo={memo} />
-            ))
-          )}
+      {ideaMemos.length === 0 ? (
+        <div className={styles.noDataContainer}>
+          <div className={styles.message}>
+            <div>まだアイデアメモがないよ。</div>
+          </div>
         </div>
-      </div>
+      ) : (
+        <div className={styles.container}>
+          <div className={styles.content}>
+            {ideaMemos.map((memo) => (
+              <IdeaMemoCard key={memo.uuid} ideaMemo={memo} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <BackButton onClick={handleBack} />
     </main>
   );
 }

--- a/front/src/app/presentation/SelectMode/SelectModePresentation.tsx
+++ b/front/src/app/presentation/SelectMode/SelectModePresentation.tsx
@@ -129,7 +129,7 @@ export function SelectModePresentation() {
           </div>
         </Button>
         <LinkButton
-          href="#"
+          href="/idea-memos"
           color="light-blue"
           size="large"
           flicker="no-flicker"

--- a/front/src/components/elements/AiGenerationLoading/AiGenerationLoading.tsx
+++ b/front/src/components/elements/AiGenerationLoading/AiGenerationLoading.tsx
@@ -16,7 +16,11 @@ export default function AiGenerationLoading() {
             </div>
           </div>
         </div>
-        <p>テーマ案生成中...</p>
+        <p>
+          テーマ案生成中...
+          <br />
+          そのままもう少し待っててね。
+        </p>
       </div>
     </div>
   );

--- a/front/src/components/elements/AlienDecoration/AlienDecoration.tsx
+++ b/front/src/components/elements/AlienDecoration/AlienDecoration.tsx
@@ -1,7 +1,7 @@
 import styles from "@/components/elements/AlienDecoration/AlienDecoration.module.scss";
 import Alien from "public/images/alien.svg";
 
-export default function AlienDecoration({ number }: { number: number }) {
+export default function AlienDecoration({ number }: { number?: number }) {
   const addZero = (num: number) => {
     if (num < 10) {
       return `0${num}`;
@@ -12,7 +12,7 @@ export default function AlienDecoration({ number }: { number: number }) {
   return (
     <div className={styles.decoration}>
       <Alien className={styles.svg} data-testid="svg" />
-      <span className={styles.number}>{addZero(number)}</span>
+      {number && <span className={styles.number}>{addZero(number)}</span>}
     </div>
   );
 }

--- a/front/src/components/elements/IdeaMemoCard/IdeaMemoCard.module.scss
+++ b/front/src/components/elements/IdeaMemoCard/IdeaMemoCard.module.scss
@@ -5,6 +5,13 @@
   align-items: center;
   border: 4px solid var(--light-gray);
   border-radius: 16px;
+  cursor: pointer;
+
+  &:hover,
+  &:active {
+    background-color: var(--light-gray);
+    opacity: 0.8;
+  }
 }
 
 .cardHeader {

--- a/front/src/components/elements/IdeaMemoCard/IdeaMemoCard.module.scss
+++ b/front/src/components/elements/IdeaMemoCard/IdeaMemoCard.module.scss
@@ -1,0 +1,69 @@
+.cardContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border: 4px solid var(--light-gray);
+  border-radius: 16px;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 12px 16px 16px 0;
+
+  @media screen and (min-width: 768px) {
+    padding: 16px 20px 20px 0;
+  }
+}
+
+// .heartIcon {
+//   height: 40px;
+//   width: auto;
+// }
+
+.cardBody {
+  width: 100%;
+  padding: 0 16px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 16px;
+
+  @media screen and (min-width: 768px) {
+    padding: 0 20px;
+  }
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+}
+
+.sectionContentContainer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  width: 100%;
+}
+
+.sectionContent {
+  width: 98%;
+}
+
+.cardFooter {
+  width: 100%;
+  text-align: end;
+  padding: 16px;
+
+  @media screen and (min-width: 768px) {
+    padding: 20px;
+  }
+}

--- a/front/src/components/elements/IdeaMemoCard/IdeaMemoCard.tsx
+++ b/front/src/components/elements/IdeaMemoCard/IdeaMemoCard.tsx
@@ -1,0 +1,57 @@
+import AlienDecoration from "@/components/elements/AlienDecoration/AlienDecoration";
+import styles from "@/components/elements/IdeaMemoCard/IdeaMemoCard.module.scss";
+import SectionTitle from "@/components/elements/SectionTitle/SectionTitle";
+import { IdeaMemoType } from "@/types";
+import { getKeyByValue } from "@/utils/enums";
+
+export default function IdeaMemoCard({ ideaMemo }: { ideaMemo: IdeaMemoType }) {
+  return (
+    <div className={styles.cardContainer}>
+      <div className={styles.cardHeader}>
+        <AlienDecoration />
+        {/* <GoHeart className={styles.heartIcon} /> */}
+      </div>
+      <div className={styles.cardBody}>
+        <div className={styles.section}>
+          <SectionTitle>テーマ</SectionTitle>
+          <div className={styles.sectionContentContainer}>
+            <div className={styles.sectionContent}>
+              {ideaMemo.ideaSession?.theme}
+            </div>
+          </div>
+        </div>
+        <div className={styles.section}>
+          <SectionTitle>観点</SectionTitle>
+          <div className={styles.sectionContentContainer}>
+            <div className={styles.sectionContent}>
+              {getKeyByValue(ideaMemo.perspective!)}
+            </div>
+          </div>
+        </div>
+        <div className={styles.section}>
+          <SectionTitle>ヒント</SectionTitle>
+          <div className={styles.sectionContentContainer}>
+            <div className={styles.sectionContent}>
+              {ideaMemo.hint || "なし"}
+            </div>
+          </div>
+        </div>
+        <div className={styles.section}>
+          <SectionTitle>回答</SectionTitle>
+          <div className={styles.sectionContentContainer}>
+            <div className={styles.sectionContent}>{ideaMemo.answer}</div>
+          </div>
+        </div>
+        <div className={styles.section}>
+          <SectionTitle>コメント</SectionTitle>
+          <div className={styles.sectionContentContainer}>
+            <div className={styles.sectionContent}>
+              {ideaMemo.comment || "なし"}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className={styles.cardFooter}>2024/3/18</div>
+    </div>
+  );
+}

--- a/front/src/components/elements/IdeaMemoCard/IdeaMemoCard.tsx
+++ b/front/src/components/elements/IdeaMemoCard/IdeaMemoCard.tsx
@@ -2,7 +2,7 @@ import AlienDecoration from "@/components/elements/AlienDecoration/AlienDecorati
 import styles from "@/components/elements/IdeaMemoCard/IdeaMemoCard.module.scss";
 import SectionTitle from "@/components/elements/SectionTitle/SectionTitle";
 import { IdeaMemoType } from "@/types";
-import { getKeyByValue } from "@/utils/enums";
+import { PerspectiveEnum } from "@/utils/enums";
 
 export default function IdeaMemoCard({ ideaMemo }: { ideaMemo: IdeaMemoType }) {
   return (
@@ -24,7 +24,11 @@ export default function IdeaMemoCard({ ideaMemo }: { ideaMemo: IdeaMemoType }) {
           <SectionTitle>観点</SectionTitle>
           <div className={styles.sectionContentContainer}>
             <div className={styles.sectionContent}>
-              {getKeyByValue(ideaMemo.perspective!)}
+              {
+                PerspectiveEnum[
+                  ideaMemo.perspective as keyof typeof PerspectiveEnum
+                ]
+              }
             </div>
           </div>
         </div>
@@ -32,7 +36,13 @@ export default function IdeaMemoCard({ ideaMemo }: { ideaMemo: IdeaMemoType }) {
           <SectionTitle>ヒント</SectionTitle>
           <div className={styles.sectionContentContainer}>
             <div className={styles.sectionContent}>
-              {ideaMemo.hint || "なし"}
+              {ideaMemo.hint && ideaMemo.perspective
+                ? `${ideaMemo.hint}を${
+                    PerspectiveEnum[
+                      ideaMemo.perspective as keyof typeof PerspectiveEnum
+                    ]
+                  }すると？`
+                : "なし"}
             </div>
           </div>
         </div>
@@ -51,7 +61,11 @@ export default function IdeaMemoCard({ ideaMemo }: { ideaMemo: IdeaMemoType }) {
           </div>
         </div>
       </div>
-      <div className={styles.cardFooter}>2024/3/18</div>
+      <div className={styles.cardFooter}>
+        {ideaMemo?.createdAt
+          ? new Date(ideaMemo.createdAt).toLocaleDateString("ja-JP")
+          : null}
+      </div>
     </div>
   );
 }

--- a/front/src/components/layouts/Header/Header.tsx
+++ b/front/src/components/layouts/Header/Header.tsx
@@ -172,7 +172,7 @@ export default function Header() {
                 </Link>
               </li>
               <li>
-                <Link href="#" onClick={menuFunction}>
+                <Link href="/idea-memos" onClick={menuFunction}>
                   <span className={styles.mainTitle}>MEMO</span>
                   <span className={styles.subTitle}>
                     保存したアイデアを確認

--- a/front/src/lib/idea-memos.ts
+++ b/front/src/lib/idea-memos.ts
@@ -1,4 +1,4 @@
-import { IdeaMemoType } from "@/types";
+import { IdeaMemoType, IdeaSessionType } from "@/types";
 import { Deserializer } from "jsonapi-serializer";
 import { getServerSession } from "next-auth";
 import { authOptions } from "./options";
@@ -61,6 +61,7 @@ export async function getCurrentIdeaMemos(
           "Content-Type": "application/json",
           Authorization: `Bearer ${session?.user.accessToken}`,
         },
+        cache: "no-store",
       },
     );
     const serializedData = await response.json();
@@ -95,6 +96,7 @@ export async function getIdeaMemosThisMonth(): Promise<number> {
           "Content-Type": "application/json",
           Authorization: `Bearer ${session?.user.accessToken}`,
         },
+        cache: "no-store",
       },
     );
     const data = await response.json();
@@ -102,6 +104,34 @@ export async function getIdeaMemosThisMonth(): Promise<number> {
       throw new Error(`アイデアの取得に失敗しました: ${data}`);
     }
     return data.count;
+  } catch (error) {
+    throw new Error(`データ取得に失敗しました: ${error}`);
+  }
+}
+
+/**
+ * アイデアメモ一覧を取得する
+ */
+export async function getAllIdeaSessionsWithMemos(): Promise<
+  IdeaSessionType[]
+> {
+  const session = await getServerSession(authOptions);
+
+  try {
+    const response = await fetch(`${BASE_URL}/api/v1/idea_memos`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${session?.user.accessToken}`,
+      },
+      cache: "no-store",
+    });
+    const serializedData = await response.json();
+    // JSON APIのデータをデシリアライズ
+    const deserializedData = await new Deserializer({
+      keyForAttribute: "camelCase",
+    }).deserialize(serializedData);
+    return deserializedData;
   } catch (error) {
     throw new Error(`データ取得に失敗しました: ${error}`);
   }

--- a/front/src/lib/idea-memos.ts
+++ b/front/src/lib/idea-memos.ts
@@ -1,4 +1,4 @@
-import { IdeaMemoType, IdeaSessionType } from "@/types";
+import { IdeaMemoType } from "@/types";
 import { Deserializer } from "jsonapi-serializer";
 import { getServerSession } from "next-auth";
 import { authOptions } from "./options";
@@ -112,9 +112,7 @@ export async function getIdeaMemosThisMonth(): Promise<number> {
 /**
  * アイデアメモ一覧を取得する
  */
-export async function getAllIdeaSessionsWithMemos(): Promise<
-  IdeaSessionType[]
-> {
+export async function getAllIdeaMemos(): Promise<IdeaMemoType[]> {
   const session = await getServerSession(authOptions);
 
   try {
@@ -127,6 +125,9 @@ export async function getAllIdeaSessionsWithMemos(): Promise<
       cache: "no-store",
     });
     const serializedData = await response.json();
+    if (serializedData === null) {
+      return [];
+    }
     // JSON APIのデータをデシリアライズ
     const deserializedData = await new Deserializer({
       keyForAttribute: "camelCase",

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -88,5 +88,6 @@ export type IdeaMemoType = {
   answer?: string;
   comment?: string | null;
   uuid?: string;
+  createdAt?: string;
   ideaSession?: IdeaSessionType;
 };

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -87,4 +87,6 @@ export type IdeaMemoType = {
   hint?: string | null;
   answer?: string;
   comment?: string | null;
+  uuid?: string;
+  ideaSession?: IdeaSessionType;
 };

--- a/front/src/utils/enums.ts
+++ b/front/src/utils/enums.ts
@@ -19,7 +19,7 @@ export enum ThemeQuestionEnum {
 /**
  * 観点Enumの定義
  */
-enum PerspectiveEnum {
+export enum PerspectiveEnum {
   modify = "変更",
   substitute = "代用",
   reverse = "逆転",


### PR DESCRIPTION
## issue番号
close #25

## やったこと
- [x]  レイアウト追加
- [x] モード選択画面から遷移できるようにする
- [x] ヘッダーリンクから遷移できるようにする
- [x] アイデア出しで保存したアイデア一覧を取得する

## やらないこと
なし

## できるようになること（ユーザ目線）
- 自分が出したアイデアの一覧が閲覧できるようになる

## できなくなること（ユーザ目線）
なし

## 動作確認
- モード選択画面・ヘッダーリンクから遷移できるよことを確認
- アイデアを出した件数が０件のときは「まだアイデアメモがないよ。」と表示されることを確認
- 自分のアイデアメモのみが表示されていることを確認

## その他
なし

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- New Feature: アイデアメモの一覧表示機能が追加され、APIから取得したメモを表示できるようになりました
- New Feature: "AIの回答を見る"ボタンの表示ロジックが更新され、特定の状態でのみ表示されるようになりました
- Refactor: `IdeaMemoType`に新しいフィールドが追加され、詳細な情報を扱えるようになりました
- Chore: APIからのデータ取得時にキャッシュを無効化するオプションが追加されました
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->