### PR TITLE
fix: AIレスポンス取得時に意図しない抽出が行われている問題を修正 #134

### DIFF
--- a/back/app/models/ai_generated_answer.rb
+++ b/back/app/models/ai_generated_answer.rb
@@ -57,7 +57,7 @@ class AiGeneratedAnswer < ApplicationRecord
   # 　ヒント内から「」で囲まれた部分を抽出する
   def self.extract_hint(full_hint)
     match = full_hint.match(/「(.*?)」/)
-    hint = match[1] if match
+    match[1] if match
   end
 
   PERSPECTIVE_MAPPING = {

--- a/back/app/models/ai_generated_answer.rb
+++ b/back/app/models/ai_generated_answer.rb
@@ -33,7 +33,7 @@ class AiGeneratedAnswer < ApplicationRecord
         hints_and_answers.each do |hint, answer|
           saved_answer = idea_session.ai_generated_answers.create!(
             perspective: AiGeneratedAnswer.perspectives[perspective_key],
-            hint: extract_hint(hint, perspective.to_s),
+            hint: extract_hint(hint),
             answer:
           )
           saved_ai_generated_answers << saved_answer
@@ -55,12 +55,9 @@ class AiGeneratedAnswer < ApplicationRecord
   end
 
   # 　ヒント内から「」で囲まれた部分を抽出する
-  def self.extract_hint(full_hint, perspective)
+  def self.extract_hint(full_hint)
     match = full_hint.match(/「(.*?)」/)
     hint = match[1] if match
-    # ヒント内に観点も含まれていた場合、ヒントから観点を削除する
-    hint.slice!(-3, 3) if hint.include?(perspective)
-    hint
   end
 
   PERSPECTIVE_MAPPING = {


### PR DESCRIPTION
## issue番号
close #134

## やったこと
- 回答のヒント部分の抽出時に判定を行い、条件にマッチすれば、文字列切り取り処理を行っていたが、意図しない抽出が行われていることがあるため、当該処理を削除

## やらないこと
なし

## できるようになること（ユーザ目線）
AIからのヒントが正常に表示されるようになります。

- 修正前は、期待値例「デザイン」で、OpenAIのレスポンスが「デザインの逆転」のようになっていた場合を考慮して、「逆転」のような観点まで含まれていたとき、は最後から３文字を削除する仕様となっていた。
- 観点を含む、かつ不要な文字列が３文字でないレスポンスの場合を確認したため、削除処理を廃止し、レスポンス通りの冗長な表現を許容する

## できなくなること（ユーザ目線）
なし

## 動作確認
ローカルにて、ヒント表示が意図せずトリムされないことをローカル環境にて確認

## その他
なし
