### PR TITLE
Feature/#111 jwt expiration

### DIFF
--- a/front/src/lib/ai-generated-themes.ts
+++ b/front/src/lib/ai-generated-themes.ts
@@ -3,6 +3,7 @@
 import { AiGeneratedThemeType, IdeaSessionType } from "@/types";
 import { Deserializer } from "jsonapi-serializer";
 import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
 import { authOptions } from "./options";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -34,6 +35,9 @@ export async function createAIGeneratedThemes(
         }),
       },
     );
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     const serializedData = await response.json();
     if (!response.ok) {
       throw new Error(`AIによるテーマ案生成に失敗しました: ${serializedData}`);
@@ -47,6 +51,9 @@ export async function createAIGeneratedThemes(
     }).deserialize(serializedData);
     return deserializedData;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }
@@ -71,6 +78,9 @@ export async function getAIGeneratedThemes(
         cache: "no-store",
       },
     );
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     const serializedData = await response.json();
     if (serializedData === null) {
       return null;
@@ -81,6 +91,9 @@ export async function getAIGeneratedThemes(
     }).deserialize(serializedData);
     return deserializedData;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }
@@ -92,7 +105,7 @@ export async function deleteAIGeneratedThemes(uuid: string): Promise<void> {
   const session = await getServerSession(authOptions);
 
   try {
-    await fetch(
+    const response = await fetch(
       `${BASE_URL}/api/v1/idea_sessions/${uuid}/ai_generated_themes`,
       {
         method: "DELETE",
@@ -102,7 +115,13 @@ export async function deleteAIGeneratedThemes(uuid: string): Promise<void> {
         },
       },
     );
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }

--- a/front/src/lib/ai-usage-history.ts
+++ b/front/src/lib/ai-usage-history.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/options";
 import { AiUsageHistoryType } from "@/types";
 import { Deserializer } from "jsonapi-serializer";
 import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
@@ -22,6 +23,9 @@ export async function getAIUsageHistory(): Promise<AiUsageHistoryType | null> {
       },
       cache: "no-store",
     });
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     if (!response.ok) {
       const errorResponse = await response.json();
       const errorMessage = errorResponse.error;
@@ -34,6 +38,9 @@ export async function getAIUsageHistory(): Promise<AiUsageHistoryType | null> {
     }).deserialize(serializedData);
     return deserializedData;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }
@@ -52,6 +59,9 @@ export async function updateAIUsageHistory(): Promise<AiUsageHistoryType> {
         Authorization: `Bearer ${session?.user.accessToken}`,
       },
     });
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     if (!response.ok) {
       const errorResponse = await response.json();
       const errorMessage = errorResponse.error;
@@ -64,6 +74,9 @@ export async function updateAIUsageHistory(): Promise<AiUsageHistoryType> {
     }).deserialize(serializedData);
     return deserializedData;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }

--- a/front/src/lib/idea-memos.ts
+++ b/front/src/lib/idea-memos.ts
@@ -3,6 +3,7 @@
 import { IdeaMemoType } from "@/types";
 import { Deserializer } from "jsonapi-serializer";
 import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
 import { authOptions } from "./options";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -17,7 +18,7 @@ const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 export async function createIdeaMemos(
   uuid: string,
   memo: IdeaMemoType,
-): Promise<IdeaMemoType> {
+): Promise<IdeaMemoType | void> {
   const session = await getServerSession(authOptions);
 
   try {
@@ -32,6 +33,9 @@ export async function createIdeaMemos(
         body: JSON.stringify({ idea_memo: { ...memo } }),
       },
     );
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     const serializedData = await response.json();
     if (!response.ok) {
       throw new Error(`アイデアの保存に失敗しました: ${serializedData}`);
@@ -42,6 +46,9 @@ export async function createIdeaMemos(
     }).deserialize(serializedData);
     return deserializedData;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }
@@ -66,6 +73,9 @@ export async function getCurrentIdeaMemos(
         cache: "no-store",
       },
     );
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     const serializedData = await response.json();
     if (serializedData === null) {
       return null;
@@ -76,6 +86,9 @@ export async function getCurrentIdeaMemos(
     }).deserialize(serializedData);
     return deserializedData;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }
@@ -98,9 +111,15 @@ export async function getIdeaMemosThisMonth(): Promise<number> {
         cache: "no-store",
       },
     );
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     const data = await response.json();
     return data.count;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }
@@ -120,6 +139,9 @@ export async function getAllIdeaMemos(): Promise<IdeaMemoType[]> {
       },
       cache: "no-store",
     });
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     const serializedData = await response.json();
     if (serializedData === null) {
       return [];
@@ -130,6 +152,9 @@ export async function getAllIdeaMemos(): Promise<IdeaMemoType[]> {
     }).deserialize(serializedData);
     return deserializedData;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }
@@ -149,6 +174,9 @@ export async function getIdeaMemo(uuid: string): Promise<IdeaMemoType> {
       },
       cache: "no-store",
     });
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     const serializedData = await response.json();
     if (!response.ok) {
       throw new Error(`データ取得に失敗しました: ${serializedData}`);
@@ -159,6 +187,9 @@ export async function getIdeaMemo(uuid: string): Promise<IdeaMemoType> {
     }).deserialize(serializedData);
     return deserializedData;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }
@@ -179,12 +210,18 @@ export async function updateIdeaMemo(uuid: string, memo: IdeaMemoType) {
       },
       body: JSON.stringify({ idea_memo: { ...memo } }),
     });
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     const data = await response.json();
     if (!response.ok) {
       throw new Error(`データ更新に失敗しました: ${data}`);
     }
     return data;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }
@@ -206,12 +243,18 @@ export async function deleteIdeaMemo(uuid: string): Promise<void> {
         Authorization: `Bearer ${session?.user.accessToken}`,
       },
     });
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     const data = await response.json();
     if (!response.ok) {
       throw new Error(`データ更新に失敗しました: ${data}`);
     }
     return data;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }

--- a/front/src/lib/idea-sessions.ts
+++ b/front/src/lib/idea-sessions.ts
@@ -3,6 +3,7 @@
 import { IdeaSessionType } from "@/types";
 import { Deserializer } from "jsonapi-serializer";
 import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
 import { authOptions } from "./options";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -23,6 +24,9 @@ export async function getIdeaSessionInProgress(): Promise<IdeaSessionType | null
         cache: "no-store",
       },
     );
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     const serializedData = await response.json();
     if (serializedData === null) {
       return null;
@@ -33,6 +37,9 @@ export async function getIdeaSessionInProgress(): Promise<IdeaSessionType | null
     }).deserialize(serializedData);
     return deserializedData;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }
@@ -56,6 +63,9 @@ export async function createIdeaSession(
         },
       }),
     });
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     const serializedData = await response.json();
     if (!response.ok) {
       throw new Error(`データ作成に失敗しました: ${serializedData}`);
@@ -66,6 +76,9 @@ export async function createIdeaSession(
     }).deserialize(serializedData);
     return deserializedData;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }
@@ -82,12 +95,18 @@ export async function deleteIdeaSession(uuid: string) {
         Authorization: `Bearer ${session?.user.accessToken}`,
       },
     });
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     const responseData = await response.json();
     if (!response.ok) {
       throw new Error(`データ削除に失敗しました: ${responseData}`);
     }
     return responseData;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }
@@ -110,6 +129,9 @@ export async function updateIdeaSession(
         idea_session: { ...data },
       }),
     });
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     const serializedData = await response.json();
     if (!response.ok) {
       throw new Error(`データ更新に失敗しました: ${serializedData}`);
@@ -120,6 +142,9 @@ export async function updateIdeaSession(
     }).deserialize(serializedData);
     return deserializedData;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }
@@ -142,6 +167,9 @@ export async function getLatestTwoIdeaSessionsWithMemos(): Promise<
         cache: "no-store",
       },
     );
+    if (response.status === 401) {
+      throw new Error("Unauthorized");
+    }
     const serializedData = await response.json();
     if (!response.ok) {
       throw new Error(`データ取得に失敗しました: ${serializedData}`);
@@ -153,6 +181,9 @@ export async function getLatestTwoIdeaSessionsWithMemos(): Promise<
 
     return deserializedData;
   } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      redirect("/auth/signin");
+    }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }
 }

--- a/front/src/middleware.ts
+++ b/front/src/middleware.ts
@@ -1,7 +1,7 @@
 export { default } from "next-auth/middleware";
 
 export const config = {
-  // 未認証でも使いたいパスはログイン制限から弾く
+  // ログインが必要なページのパスを指定
   matcher: [
     "/select-mode",
     "/:path/check-theme",


### PR DESCRIPTION
## issue番号
close #111 

## やったこと
- [ ]  JWTの有効期限が切れたらログインページに遷移するようにする

## やらないこと
なし

## できるようになること（ユーザ目線）
【対応前】JWTの有効期限が切れると、内部エラーページが表示されていた
【対応後】JWTの有効期限が切れると、ログインページが表示されるようになる

## できなくなること（ユーザ目線）
なし

## 動作確認
JWTの有効期限を以下のように修正し、期限切れになると、要認証ページや要認証操作実行時に、ログインページが表示されるようになることを確認しました。
// front/src/lib/options.ts
```
  session: {
    strategy: "jwt",
    // maxAge: 24 * 60 * 60, // 24 hours
    maxAge: 60, // 60 seconds
  },
  jwt: {
    // maxAge: 24 * 60 * 60, // 24 hours
    maxAge: 60, // 60 seconds
  },
```

## その他
なし
