### PR TITLE
add: お問合せフォームの追加 #33

### DIFF
--- a/front/src/components/layouts/Footer/Footer.test.tsx
+++ b/front/src/components/layouts/Footer/Footer.test.tsx
@@ -39,6 +39,9 @@ describe("Footer", () => {
     render(<Footer />);
 
     const contactLink = screen.getByRole("link", { name: "Contact" });
-    expect(contactLink).toHaveAttribute("href", "/contact");
+    expect(contactLink).toHaveAttribute(
+      "href",
+      "https://docs.google.com/forms/d/13za2tbR2mP3k-M6KxeXCY-akmZFMZkEalpAKsnHESgc/edit",
+    );
   });
 });

--- a/front/src/components/layouts/Footer/Footer.tsx
+++ b/front/src/components/layouts/Footer/Footer.tsx
@@ -35,7 +35,9 @@ export default function Footer() {
             <Link href="/terms">Terms of Use</Link>
           </li>
           <li>
-            <Link href="/contact">Contact</Link>
+            <Link href="https://docs.google.com/forms/d/13za2tbR2mP3k-M6KxeXCY-akmZFMZkEalpAKsnHESgc/edit">
+              Contact
+            </Link>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## issue番号
close #33

## やったこと
- Google Formでお問合せフォームを作成
- フッターリンクから、お問合せフォームに遷移できるように設定

## やらないこと
なし

## できるようになること（ユーザ目線）
フォームから、お問い合わせができるようになります。

## できなくなること（ユーザ目線）
なし

## 動作確認
ローカル環境にて、フッターのリンクから、作成したGoogle Formに遷移できることを確認しました。

## その他
なし
