### PR TITLE
Feature/#152 update specification

### DIFF
--- a/front/src/app/presentation/GenerateIdeas/GenerateIdeasPresentation.tsx
+++ b/front/src/app/presentation/GenerateIdeas/GenerateIdeasPresentation.tsx
@@ -120,6 +120,9 @@ export default function GenerateIdeasPresentation({
               setHasApiError(true);
             }
             setAiGeneratedAnswers(data.body);
+            toast("AIからヒントと回答例が届いたよ！", {
+              icon: "🚀",
+            });
             // AIの回答生成が成功したのでideaSessionのis_ai_answer_generatedをtrueにする
             await updateIdeaSession(uuid, { isAiAnswerGenerated: true });
           };
@@ -168,6 +171,13 @@ export default function GenerateIdeasPresentation({
       ref?.current?.reset();
     }
   };
+
+  // フォーム入力エラーがあった場合はトースト表示
+  useEffect(() => {
+    if (myIdeaState?.errors?.idea) {
+      toast.error("エラーがあるよ。確認してね。");
+    }
+  }, [myIdeaState?.errors?.idea]);
 
   // スクロールを一番上に戻す
   const scrollToTop = () => {

--- a/front/src/app/presentation/GenerateTheme/GenerateThemePresentation.tsx
+++ b/front/src/app/presentation/GenerateTheme/GenerateThemePresentation.tsx
@@ -43,6 +43,7 @@ import Error from "next/error";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useFormState, useFormStatus } from "react-dom";
+import toast from "react-hot-toast";
 import { BsExclamationTriangle } from "react-icons/bs";
 
 export default function GenerateThemePresentation({
@@ -85,6 +86,21 @@ export default function GenerateThemePresentation({
     confirmTheme,
     initialGeneratedThemesState,
   );
+
+  // フォームエラーがあった場合はトーストを表示
+  useEffect(() => {
+    if (
+      questionState?.errors?.option ||
+      questionState?.errors?.answer ||
+      generatedThemesState?.errors?.option
+    ) {
+      toast.error("エラーがあるよ。確認してね。");
+    }
+  }, [
+    questionState?.errors?.option,
+    questionState?.errors?.answer,
+    generatedThemesState?.errors?.option,
+  ]);
 
   // 遷移先パスをプレフェッチ
   useEffect(() => {

--- a/front/src/app/presentation/IdeaMemosUuid/IdeaMemosUuidPresentation.tsx
+++ b/front/src/app/presentation/IdeaMemosUuid/IdeaMemosUuidPresentation.tsx
@@ -22,7 +22,7 @@ import { IdeaMemoType } from "@/types";
 import { PerspectiveEnum } from "@/utils/enums";
 import { AlertCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { useFormState, useFormStatus } from "react-dom";
 import toast from "react-hot-toast";
 import { GiCancel } from "react-icons/gi";
@@ -93,6 +93,13 @@ export default function IdeaMemosUuidPresentation({
     }
     return result;
   }, initialIdeaMemoState);
+
+  // フォームエラーがあった場合はトーストを表示
+  useEffect(() => {
+    if (ideaMemoState?.errors?.idea || ideaMemoState?.errors?.comment) {
+      toast.error("エラーがあるよ。確認してね。");
+    }
+  }, [ideaMemoState?.errors?.idea, ideaMemoState?.errors?.comment]);
 
   // 戻るボタンの処理
   const handleBack = () => {

--- a/front/src/app/presentation/InputTheme/InputThemePresentation.tsx
+++ b/front/src/app/presentation/InputTheme/InputThemePresentation.tsx
@@ -22,6 +22,7 @@ import Error from "next/error";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useFormState, useFormStatus } from "react-dom";
+import toast from "react-hot-toast";
 import {
   FaRegFaceFrown,
   FaRegFaceGrin,
@@ -44,6 +45,13 @@ export default function InputThemePresentation({
     errors: {},
   };
   const [state, dispatch] = useFormState(submitTheme, initialState);
+
+  // フォーム入力エラーがあれば、トースト表示
+  useEffect(() => {
+    if (state?.errors?.theme) {
+      toast.error("エラーがあるよ。確認してね。");
+    }
+  }, [state?.errors?.theme]);
 
   // 遷移先パスをプレフェッチ
   useEffect(() => {

--- a/front/src/app/presentation/SelectMode/SelectModePresentation.tsx
+++ b/front/src/app/presentation/SelectMode/SelectModePresentation.tsx
@@ -7,10 +7,10 @@ import { ToastAction } from "@/components/ui/toast";
 import { useToast } from "@/components/ui/use-toast";
 import { COUNT_LIMIT } from "@/constants/constants";
 import { useDialog } from "@/hooks/useDialog";
+import { endSession } from "@/lib/actions";
 import { getAIUsageHistory } from "@/lib/ai-usage-history";
 import {
   createIdeaSession,
-  deleteIdeaSession,
   getIdeaSessionInProgress,
 } from "@/lib/idea-sessions";
 import { generateUUID } from "@/lib/uuid";
@@ -108,7 +108,7 @@ export function SelectModePresentation() {
       handleModalYesClick(sessionInProgress);
     } else {
       // 新しくスタートする場合
-      await deleteIdeaSession(sessionInProgress.uuid);
+      await endSession(sessionInProgress.uuid); // 旧セッション終了処理
       const uuid = generateUUID();
       await createIdeaSession(uuid);
       router.push(`/${encodeURIComponent(uuid)}/check-theme`);
@@ -157,7 +157,7 @@ export function SelectModePresentation() {
               <>
                 アイデア出しの途中で中断されたセッションがあるよ。続きから始める？
                 <br />
-                ※「新しくスタート」を選択すると、途中のセッション内容や、出したアイデアメモは削除されるので注意してね。
+                ※「新しくスタート」を選択すると、途中のセッションには戻れないので注意してね。
               </>
             }
             trueVal="続きから"

--- a/front/src/app/presentation/SelectThemeCategory/SelectThemeCategoryPresentation.tsx
+++ b/front/src/app/presentation/SelectThemeCategory/SelectThemeCategoryPresentation.tsx
@@ -15,7 +15,9 @@ import { ThemeCategoryEnum } from "@/utils/enums";
 import { AlertCircle } from "lucide-react";
 import Error from "next/error";
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 import { useFormState, useFormStatus } from "react-dom";
+import toast from "react-hot-toast";
 
 export default function SelectThemePresentation({
   ideaSession,
@@ -30,6 +32,13 @@ export default function SelectThemePresentation({
     errors: {},
   };
   const [state, dispatch] = useFormState(submitThemeCategory, initialState);
+
+  // フォームエラーがあった場合はトーストを表示
+  useEffect(() => {
+    if (state?.errors?.option) {
+      toast.error("エラーがあるよ。確認してね。");
+    }
+  }, [state?.errors?.option]);
 
   // ラジオボタンの選択肢
   const options: Option[] = Object.entries(ThemeCategoryEnum).map(

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -120,6 +120,7 @@ export type ThemeQuestionState = {
     option?: string[];
     answer?: string[];
   };
+  invalid?: boolean;
 };
 
 const selectOptions = Object.keys(ThemeQuestionEnum);
@@ -142,7 +143,7 @@ const ThemeQuestionSchema = z.object({
 export const generateThemes = async (
   prevState: ThemeQuestionState | undefined,
   formData: FormData,
-) => {
+): Promise<ThemeQuestionState | undefined> => {
   // ThemeQuestionSchemaによるバリデーション
   const validatedThemeQuestion = ThemeQuestionSchema.safeParse({
     option: formData.get("option"),
@@ -174,11 +175,7 @@ export const generateThemes = async (
     );
     if (!aiGeneratedThemes) {
       return {
-        errors: {
-          answer: [
-            "無効なデータが入力されたよ。適切な入力に修正して、再度実行してね。",
-          ],
-        },
+        invalid: true,
       };
     }
     redirect(`/${uuid}/generate-theme`);


### PR DESCRIPTION
## issue番号
close #152

## やったこと
- [x] テーマ生成時のOpen AI APIリクエストで無効な入力があったと判断された際にエラーがダイアログで表示されるようにする
- [x] 新しいセッション開始時に、途中のセッションで出したアイデアメモを残せるようにする
- [x] フォーム入力エラー発生時、スマホだとフォーム上にエラーを表示しただけだとわかりづらいため、トーストも表示するようにする
- [x] AIのヒント、回答生成完了時にも、完了通知トーストを出すようにする

## やらないこと
なし

## できるようになること（ユーザ目線）
- テーマ生成時のOpen AI APIリクエストで無効な入力があったと判断された際にエラーがダイアログで表示されるようになることで、よりエラーがあったことが伝わりやすくなります。
- 新しいセッションを開始しても、途中のセッションで出したアイデアメモを確認できるようになります。
- エラー発生時や、AIレスポンス返却完了時にトースト表示が行われることで、よりエラーがあったことが伝わりやすくなります。

## できなくなること（ユーザ目線）
なし

## 動作確認
ローカル環境にて、以下を確認しました。
- 無効な入力があった場合、ダイアログが表示されること
- 途中のセッションがある状態で、新しいセッションを始めても、旧セッションでだしたアイデアがアイデアメモから確認できること
- フォーム入力エラーがあった場合にエラートーストが表示されること
- AIからの回答・ヒントレスポンスが返ってきた際に通知トーストが表示されること

## その他
なし
