### PR TITLE
fix: iOSデバイスでテキストボックスフォーカス時に拡大表示される問題を修正 #161

### DIFF
--- a/front/src/components/elements/Textbox/Textbox.module.scss
+++ b/front/src/components/elements/Textbox/Textbox.module.scss
@@ -4,11 +4,7 @@
 }
 
 .textarea {
-  height: 6rem;
-
-  @media screen and (min-width: 768px) {
-    height: 8rem;
-  }
+  height: 10rem;
 }
 
 .microphone {

--- a/front/src/components/ui/textarea.tsx
+++ b/front/src/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-slate-900 ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-lg text-slate-900 ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}


### PR DESCRIPTION
## issue番号
close #161

## やったこと
iOSデバイスでテキストボックスフォーカス時に拡大表示される問題を修正しました。
※iOSではテキストボックスのフォントサイズが16px以下の場合、拡大表示される仕様のため、フォントサイズを拡大しました

## やらないこと
なし

## できるようになること（ユーザ目線）
テキストボックスフォーカス時に拡大表示されなくなるので、レイアウト全体が拡大されず、見やすいレイアウトが維持されます。

## できなくなること（ユーザ目線）
なし

## 動作確認
実機未確認

## その他
なし
