### PR TITLE
fix: テーマカテゴリー選択時に、点滅しているようなUIになるため修正 #163

### DIFF
--- a/front/src/components/elements/ThemeCategoryRadioButtons/ThemeCategoryRadioButtons.module.scss
+++ b/front/src/components/elements/ThemeCategoryRadioButtons/ThemeCategoryRadioButtons.module.scss
@@ -61,7 +61,6 @@
     }
   }
 
-  &:active,
   &.selected {
     border: none;
 


### PR DESCRIPTION
## issue番号
#163

## やったこと
テーマカテゴリー選択時に、`active`と`.selected`の両方で色付けするCSSを記載しているためか、点滅しているようなUIになるため、`active`を削除することで修正しました

## やらないこと
なし

## できるようになること（ユーザ目線）
テーマカテゴリー選択時に、点滅なく色付けされるようになります。

## できなくなること（ユーザ目線）
なし

## 動作確認
実機未確認

## その他
なし
