### PR TITLE
Google Analytics用設定記述位置修正

### DIFF
--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -63,8 +63,8 @@ export default function RootLayout({
             <Footer />
           </TouchProvider>
         </NextAuthProvider>
-        <GoogleAnalytics gaId="G-ZER08G5VVW" />
       </body>
+      <GoogleAnalytics gaId="G-ZER08G5VVW" />
     </html>
   );
 }


### PR DESCRIPTION
## issue番号
#172 

## やったこと
「ウェブサイトで Google タグが検出されませんでした。」となり、Google Analyticsが登録できていない問題が発生していたため、設定方法を修正しました。

- Google Analytics用のコンポーネントがbodyタグの中に入っていたことが原因と考え、修正

## やらないこと
なし

## できるようになること（ユーザ目線）
なし

## できなくなること（ユーザ目線）
なし

## 動作確認
未確認

## その他
なし
