### PR TITLE
GA4測定IDの修正 #172

### DIFF
--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -64,7 +64,7 @@ export default function RootLayout({
           </TouchProvider>
         </NextAuthProvider>
       </body>
-      <GoogleAnalytics gaId="G-ZER08G5VVW" />
+      <GoogleAnalytics gaId="G-BJ7Z6RGZJF" />
     </html>
   );
 }


### PR DESCRIPTION
## issue番号
#172

## やったこと
GA4ストリームが消えていたため、再作成し、新たな測定IDを設定しました。

## やらないこと
なし

## できるようになること（ユーザ目線）
なし

## できなくなること（ユーザ目線）
なし

## 動作確認
未確認

## その他
なし
