### PR TITLE
ダイアログ文字が背景色と同化し、見えなくなっていた問題を修正 #176

### DIFF
--- a/front/src/app/presentation/GenerateIdeas/GenerateIdeasPresentation.tsx
+++ b/front/src/app/presentation/GenerateIdeas/GenerateIdeasPresentation.tsx
@@ -457,7 +457,7 @@ export default function GenerateIdeasPresentation({
         >
           <AlertDialogContent>
             <AlertDialogHeader>
-              <>
+              <AlertDialogDescription className="text-left">
                 {(ideaSession?.aiAnswerRetryCount ?? 0) <= 2 ? (
                   <>
                     無効なテーマだと判断されたよ。
@@ -471,7 +471,7 @@ export default function GenerateIdeasPresentation({
                     新しいセッションを作成するので、もう一度やってみてね。
                   </>
                 )}
-              </>
+              </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter className="flex-col sm:flex-row gap-4 sm:gap-0">
               <AlertDialogAction onClick={handleOkClick}>OK</AlertDialogAction>


### PR DESCRIPTION
## issue番号
close #176

## やったこと
アイデア出し画面のAlertDialogDescriptionコンポーネントの記載が漏れていたため、ダイアログ文字が背景色と同化し、見えなくなっていた問題を修正しました。

## やらないこと
なし

## できるようになること（ユーザ目線）
アイデア出し画面で向こうな入力をした場合に、アラート表示の文字が確認できるようになります。

## できなくなること（ユーザ目線）
なし

## 動作確認
ローカル環境にて、以下の通りダイアログの文字が視認できることを確認しました。
![Screenshot 2024-04-03 at 20 27 21](https://github.com/meimei-kr/idea-space-trip/assets/77828683/735e0463-1f55-46ff-b3f1-f96e6d034d40)


## その他
なし
