### PR TITLE
アイデアメモお気に入り登録機能修正漏れ反映 #34

### DIFF
--- a/back/app/controllers/api/v1/idea_memos_controller.rb
+++ b/back/app/controllers/api/v1/idea_memos_controller.rb
@@ -41,7 +41,9 @@ module Api
         idea_memo = @idea_session.idea_memos.new(idea_memo_params)
 
         if idea_memo.save
-          render json: IdeaMemoSerializer.new(idea_memo).serializable_hash.to_json, status: :ok
+          render json: IdeaMemoSerializer.new(idea_memo,
+                                              { params: { current_user: @current_user } })
+                                         .serializable_hash.to_json, status: :ok
         else
           render json: { errors: idea_memo.errors }, status: :unprocessable_entity
         end
@@ -53,7 +55,9 @@ module Api
         if idea_memos.empty?
           render json: nil, status: :ok
         else
-          render json: IdeaMemoSerializer.new(idea_memos).serializable_hash.to_json, status: :ok
+          render json: IdeaMemoSerializer.new(idea_memos,
+                                              { params: { current_user: @current_user } })
+                                         .serializable_hash.to_json, status: :ok
         end
       end
 

--- a/back/app/controllers/api/v1/idea_sessions_controller.rb
+++ b/back/app/controllers/api/v1/idea_sessions_controller.rb
@@ -48,7 +48,10 @@ module Api
         if idea_sessions.empty?
           render json: { error: '対象のidea_sessionデータが見つかりませんでした。' }, status: :not_found
         else
-          render json: IdeaSessionSerializer.new(idea_sessions, options).serializable_hash.to_json,
+          render json: IdeaSessionSerializer.new(idea_sessions,
+                                                 { params: { current_user: @current_user },
+                                                   include: [:idea_memos] })
+                                            .serializable_hash.to_json,
                  status: :ok
         end
       end
@@ -73,12 +76,6 @@ module Api
 
       def set_idea_session
         @current_user.idea_sessions.find_by(uuid: params[:uuid])
-      end
-
-      def options
-        options = {}
-        options[:include] = %i[idea_memos]
-        options
       end
     end
   end

--- a/front/src/components/elements/IdeaMemoCard/IdeaMemoCard.module.scss
+++ b/front/src/components/elements/IdeaMemoCard/IdeaMemoCard.module.scss
@@ -31,3 +31,10 @@
     padding: 20px;
   }
 }
+
+.linkContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  flex: 1;
+}

--- a/front/src/components/elements/IdeaMemoCard/IdeaMemoCard.tsx
+++ b/front/src/components/elements/IdeaMemoCard/IdeaMemoCard.tsx
@@ -18,7 +18,10 @@ export default function IdeaMemoCard({ ideaMemo }: { ideaMemo: IdeaMemoType }) {
       onTouchEnd={handleTouchEnd}
     >
       <IdeaMemoCardHeader ideaMemo={ideaMemo} />
-      <Link href={`/idea-memos/${ideaMemo.uuid}`}>
+      <Link
+        href={`/idea-memos/${ideaMemo.uuid}`}
+        className={styles.linkContainer}
+      >
         <IdeaMemoCardContent ideaMemo={ideaMemo} />
         <IdeaMemoCardFooter ideaMemo={ideaMemo} />
       </Link>

--- a/front/src/components/elements/LikeListButton/LikeListButton.tsx
+++ b/front/src/components/elements/LikeListButton/LikeListButton.tsx
@@ -31,12 +31,15 @@ export default function LikeListButton() {
   };
 
   return (
-    <div className={styles.likeListButton}>
+    <button
+      className={styles.likeListButton}
+      onClick={isLikeListClicked ? handleShowAll : handleShowLikeList}
+    >
       {isLikeListClicked ? (
-        <FiHeart className={styles.like} onClick={handleShowAll} />
+        <FiHeart className={styles.like} />
       ) : (
-        <FiHeart className={styles.unlike} onClick={handleShowLikeList} />
+        <FiHeart className={styles.unlike} />
       )}
-    </div>
+    </button>
   );
 }


### PR DESCRIPTION
## issue番号
#34

## やったこと
- レイアウト崩れ修正
- IdeaMemoSerializerにパラメーターとしてユーザー情報を渡す仕様変更に伴い、エラーになっていた箇所を修正
- お気に入り一覧表示ボタン全体をクリック可能要素に変更

## やらないこと
なし

## できるようになること（ユーザ目線）
お気に入り一覧表示ボタン内のどこをクリックしても、お気に入り一覧が表示できるようになる

## できなくなること（ユーザ目線）
なし

## 動作確認
- レイアウト崩れ、エラーが解消されていることを確認
- お気に入り一覧表示ボタン内のどこをクリックしても、お気に入り一覧が表示できることを確認

## その他
なし
