### PR TITLE
フォームのある箇所で文字数カウントを表示するよう変更 #178

### DIFF
--- a/front/src/components/elements/Textbox/Textbox.module.scss
+++ b/front/src/components/elements/Textbox/Textbox.module.scss
@@ -1,3 +1,7 @@
+.textareaWrapper {
+  width: 100%;
+}
+
 .textareaContainer {
   width: 100%;
   position: relative;
@@ -14,4 +18,18 @@
   color: var(--black);
   width: 20px;
   height: 20px;
+}
+
+.characterCount {
+  width: 100%;
+  text-align: right;
+  font-size: 12px;
+
+  span {
+    font-size: 16px;
+  }
+}
+
+.overLimit {
+  color: var(--red);
 }

--- a/front/src/components/elements/Textbox/Textbox.tsx
+++ b/front/src/components/elements/Textbox/Textbox.tsx
@@ -14,7 +14,9 @@ export default function Textbox({
   placeholder,
   defaultValue,
 }: TextboxProps) {
-  const [characterCount, setCharacterCount] = useState(0);
+  const [characterCount, setCharacterCount] = useState(
+    defaultValue?.length || 0,
+  );
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setCharacterCount(e.target.value.length);

--- a/front/src/components/elements/Textbox/Textbox.tsx
+++ b/front/src/components/elements/Textbox/Textbox.tsx
@@ -1,6 +1,10 @@
+"use client";
+
 import styles from "@/components/elements/Textbox/Textbox.module.scss";
 import { Textarea } from "@/components/ui/textarea";
+import { FORM_CHARACTER_LIMIT } from "@/constants/constants";
 import type { TextboxProps } from "@/types";
+import { useState } from "react";
 // import { FaMicrophone } from "react-icons/fa6";
 
 export default function Textbox({
@@ -10,17 +14,35 @@ export default function Textbox({
   placeholder,
   defaultValue,
 }: TextboxProps) {
+  const [characterCount, setCharacterCount] = useState(0);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setCharacterCount(e.target.value.length);
+  };
+
   return (
-    <div className={styles.textareaContainer}>
-      <Textarea
-        id={id}
-        name={name}
-        aria-describedby={ariaDescribedby}
-        placeholder={placeholder}
-        className={styles.textarea}
-        defaultValue={defaultValue}
-      />
-      {/* <FaMicrophone className={styles.microphone} /> */}
+    <div className={styles.textareaWrapper}>
+      <div className={styles.textareaContainer}>
+        <Textarea
+          id={id}
+          name={name}
+          aria-describedby={ariaDescribedby}
+          placeholder={placeholder}
+          className={styles.textarea}
+          defaultValue={defaultValue}
+          onChange={handleChange}
+        />
+        {/* <FaMicrophone className={styles.microphone} /> */}
+      </div>
+      <div className={styles.characterCount}>
+        あと{" "}
+        <span
+          className={`${FORM_CHARACTER_LIMIT - characterCount < 0 ? styles.overLimit : ""}`}
+        >
+          {FORM_CHARACTER_LIMIT - characterCount}
+        </span>{" "}
+        文字
+      </div>
     </div>
   );
 }

--- a/front/src/constants/constants.ts
+++ b/front/src/constants/constants.ts
@@ -13,3 +13,5 @@ export const ITEMS_PER_PAGE = 6;
 export const FIRST_COMMEND_MESSAGE_COUNT = 5;
 
 export const COMMEND_MESSAGE_INTERVAL = 10;
+
+export const FORM_CHARACTER_LIMIT = 255;

--- a/front/src/features/generate-ideas/components/MyIdeaForm/MyIdeaForm.tsx
+++ b/front/src/features/generate-ideas/components/MyIdeaForm/MyIdeaForm.tsx
@@ -3,6 +3,7 @@
 import ErrorAlert from "@/components/elements/ErrorAlert/ErrorAlert";
 import Textbox from "@/components/elements/Textbox/Textbox";
 import { LitUpBorders } from "@/components/ui/tailwind-buttons";
+import { FORM_CHARACTER_LIMIT } from "@/constants/constants";
 import styles from "@/features/generate-ideas/components/MyIdeaForm/MyIdeaForm.module.scss";
 import { MyIdeaState, submitMyIdea } from "@/lib/actions";
 import { PerspectiveType } from "@/types";
@@ -63,7 +64,7 @@ export default function MyIdeaForm({
         id="idea"
         name="idea"
         ariaDescribedby="idea-error"
-        placeholder="思いついたアイデアを入力してね（255文字以内）"
+        placeholder={`思いついたアイデアを入力してね（${FORM_CHARACTER_LIMIT}文字以内）`}
       />
       <input
         type="hidden"

--- a/front/src/features/generate-theme/components/AnswerForm/AnswerForm.tsx
+++ b/front/src/features/generate-theme/components/AnswerForm/AnswerForm.tsx
@@ -7,6 +7,7 @@ import SectionTitle from "@/components/elements/SectionTitle/SectionTitle";
 import Textbox from "@/components/elements/Textbox/Textbox";
 import { AlertDialog, AlertDialogContent } from "@/components/ui/alert-dialog";
 import { LitUpBordersLg } from "@/components/ui/tailwind-buttons";
+import { FORM_CHARACTER_LIMIT } from "@/constants/constants";
 import styles from "@/features/generate-theme/components/AnswerForm/AnswerForm.module.scss";
 import SelectOptions from "@/features/generate-theme/components/SelectOptions/SelectOptions";
 import { useUUIDCheck } from "@/hooks/useUUIDCheck";
@@ -141,7 +142,7 @@ export default function AnswerForm({
             id="answer"
             name="answer"
             ariaDescribedby="theme-answer-error"
-            placeholder="255文字以内で回答を入力してね。複数回答してもOKだよ。"
+            placeholder={`${FORM_CHARACTER_LIMIT}文字以内で回答を入力してね。複数回答してもOKだよ。`}
           />
         </div>
       </div>

--- a/front/src/features/idea-memos-uuid/components/EditForm/EditForm.tsx
+++ b/front/src/features/idea-memos-uuid/components/EditForm/EditForm.tsx
@@ -4,6 +4,7 @@ import ErrorAlert from "@/components/elements/ErrorAlert/ErrorAlert";
 import SectionTitle from "@/components/elements/SectionTitle/SectionTitle";
 import Textbox from "@/components/elements/Textbox/Textbox";
 import { LitUpBordersLg } from "@/components/ui/tailwind-buttons";
+import { FORM_CHARACTER_LIMIT } from "@/constants/constants";
 import styles from "@/features/idea-memos-uuid/components/EditForm/EditForm.module.scss";
 import { IdeaMemoState, submitUpdateIdeaMemo } from "@/lib/actions";
 import { IdeaMemoType } from "@/types";
@@ -88,7 +89,7 @@ export default function EditMode({
             id="idea"
             name="idea"
             ariaDescribedby="idea-error"
-            placeholder="255文字以内"
+            placeholder={`${FORM_CHARACTER_LIMIT}文字以内`}
             defaultValue={ideaMemo.answer}
           />
         </div>
@@ -103,7 +104,7 @@ export default function EditMode({
             id="comment"
             name="comment"
             ariaDescribedby="comment-error"
-            placeholder="255文字以内"
+            placeholder={`${FORM_CHARACTER_LIMIT}文字以内`}
             defaultValue={ideaMemo.comment ?? ""}
           />
         </div>

--- a/front/src/features/input-theme/components/Form/Form.tsx
+++ b/front/src/features/input-theme/components/Form/Form.tsx
@@ -4,6 +4,7 @@ import AlertModal from "@/components/elements/AlertModal/AlertModal";
 import ErrorAlert from "@/components/elements/ErrorAlert/ErrorAlert";
 import Textbox from "@/components/elements/Textbox/Textbox";
 import { LitUpBordersLg } from "@/components/ui/tailwind-buttons";
+import { FORM_CHARACTER_LIMIT } from "@/constants/constants";
 import styles from "@/features/input-theme/components/Form/Form.module.scss";
 import { useUUIDCheck } from "@/hooks/useUUIDCheck";
 import { ThemeState, submitTheme } from "@/lib/actions";
@@ -71,7 +72,7 @@ export default function Form({
           id="theme"
           name="theme"
           ariaDescribedby="theme-error"
-          placeholder="255文字以内で入力してね"
+          placeholder={`${FORM_CHARACTER_LIMIT}文字以内で入力してね`}
         />
         <p className={styles.checkItem}>
           <IoCheckboxOutline />

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { FORM_CHARACTER_LIMIT } from "@/constants/constants";
 import {
   createAIGeneratedThemes,
   deleteAIGeneratedThemes,
@@ -32,7 +33,9 @@ const ThemeSchema = z.object({
     .string()
     .trim()
     .min(1, { message: "テーマの入力は必須だよ" })
-    .max(255, { message: "テーマは255文字以内で入力してね" }),
+    .max(FORM_CHARACTER_LIMIT, {
+      message: `テーマは${FORM_CHARACTER_LIMIT}文字以内で入力してね`,
+    }),
   uuid: z.string(), // uuidはhiddenで自動的に送信されるため、厳密なバリデーションは不要
 });
 
@@ -138,7 +141,9 @@ const ThemeQuestionSchema = z.object({
     .string()
     .trim()
     .min(1, { message: "回答入力は必須だよ" })
-    .max(255, { message: "回答は255文字以内で入力してね" }),
+    .max(FORM_CHARACTER_LIMIT, {
+      message: `回答は${FORM_CHARACTER_LIMIT}文字以内で入力してね`,
+    }),
   uuid: z.string(), // uuidはhiddenで自動的に送信されるため、厳密なバリデーションは不要
 });
 
@@ -253,7 +258,9 @@ const IdeaSchema = z.object({
     .string()
     .trim()
     .min(1, { message: "アイデアの入力は必須だよ" })
-    .max(255, { message: "アイデアは255文字以内で入力してね" }),
+    .max(FORM_CHARACTER_LIMIT, {
+      message: `アイデアは${FORM_CHARACTER_LIMIT}文字以内で入力してね`,
+    }),
   uuid: z.string(), // uuidはhiddenで自動的に送信されるため、厳密なバリデーションは不要
   perspective: z.string(), // perspectiveはhiddenで自動的に送信されるため、厳密なバリデーションは不要
 });
@@ -322,11 +329,15 @@ const IdeaMemoSchema = z.object({
     .string()
     .trim()
     .min(1, { message: "回答の入力は必須だよ" })
-    .max(255, { message: "回答は255文字以内で入力してね" }),
+    .max(FORM_CHARACTER_LIMIT, {
+      message: `回答は${FORM_CHARACTER_LIMIT}文字以内で入力してね`,
+    }),
   comment: z
     .string()
     .trim()
-    .max(255, { message: "コメントは255文字以内で入力してね" }),
+    .max(FORM_CHARACTER_LIMIT, {
+      message: `コメントは${FORM_CHARACTER_LIMIT}文字以内で入力してね`,
+    }),
   uuid: z.string(), // uuidはhiddenで自動的に送信されるため、厳密なバリデーションは不要
 });
 


### PR DESCRIPTION
## issue番号
close #178

## やったこと
- [x] テキストボックスフォームで文字数カウントを表示するよう変更

## やらないこと
なし

## できるようになること（ユーザ目線）
テキストボックスフォーム入力時に残りの文字数を表示できるようになります。

## できなくなること（ユーザ目線）
なし

## 動作確認
- テーマ入力画面
<img width="739" alt="Screenshot 2024-04-19 at 11 46 08" src="https://github.com/meimei-kr/idea-space-trip/assets/77828683/8344378a-a3a8-440a-9b84-fec786f9212a">

 - テーマ案生成画面
<img width="719" alt="Screenshot 2024-04-19 at 11 49 24" src="https://github.com/meimei-kr/idea-space-trip/assets/77828683/39bf1fec-b4e3-40e5-b18f-036ccf48df4a">

- アイデア出し画面
<img width="725" alt="Screenshot 2024-04-19 at 11 30 30" src="https://github.com/meimei-kr/idea-space-trip/assets/77828683/5347b7ce-50c6-4b6a-93ed-a736b1e0c2a9">

- アイデアメモ編集画面
<img width="813" alt="Screenshot 2024-04-19 at 11 43 12" src="https://github.com/meimei-kr/idea-space-trip/assets/77828683/52112dec-b4a1-40b5-8fc4-fdb266802739">

## その他
なし
