### PR TITLE
テーマ案生成時にEdge Functionsで実行されるよう設定 #186

### DIFF
--- a/front/src/app/[uuid]/generate-theme/page.tsx
+++ b/front/src/app/[uuid]/generate-theme/page.tsx
@@ -6,6 +6,8 @@ import { getAIGeneratedThemes } from "@/lib/ai-generated-themes";
 import { getIdeaSessionInProgress } from "@/lib/idea-sessions";
 import { AiGeneratedThemeType, Option } from "@/types";
 
+export const runtime = "edge";
+
 export default async function page({ params }: { params: { uuid: string } }) {
   // 進行中のアイデアセッションを取得
   const ideaSession = await getIdeaSessionInProgress();


### PR DESCRIPTION
## issue番号
#186

## やったこと
Serverless Functionsを利用すると、vercelのHobbyプランでは10秒でタイムアウトしてしまうため、タイムアウトまで25秒あるEdge Functionsに移行する設定を追加しました。

## やらないこと
なし

## できるようになること（ユーザ目線）
Vercelのタイムアウトエラーなく利用できるようになります。

## できなくなること（ユーザ目線）
なし

## 動作確認
未確認

## その他
なし
