### PR TITLE
maxDurationを設定することでタイムアウト防止

### DIFF
--- a/front/src/app/[uuid]/generate-theme/page.tsx
+++ b/front/src/app/[uuid]/generate-theme/page.tsx
@@ -6,6 +6,8 @@ import { getAIGeneratedThemes } from "@/lib/ai-generated-themes";
 import { getIdeaSessionInProgress } from "@/lib/idea-sessions";
 import { AiGeneratedThemeType, Option } from "@/types";
 
+export const maxDuration = 60;
+
 export default async function page({ params }: { params: { uuid: string } }) {
   // 進行中のアイデアセッションを取得
   const ideaSession = await getIdeaSessionInProgress();


### PR DESCRIPTION
## issue番号
close #191

## やったこと
- [x]  vercel hobbyプランではタイムアウトがMax10秒までなので、proプランに変更し、タイムアウト値を60秒に変更

## やらないこと
なし

## できるようになること（ユーザ目線）
テーマ案生成時にOpenAI APIコールに時間がかかってもタイムアウトしないようになります。

## できなくなること（ユーザ目線）
なし

## 動作確認
未確認

## その他
なし
