### PR TITLE
アイデアメモ詳細表示時に無効なURLであれば404エラーページを表示するよう修正 #193

### DIFF
--- a/front/src/lib/idea-memos.ts
+++ b/front/src/lib/idea-memos.ts
@@ -4,7 +4,7 @@ import { IdeaMemoType } from "@/types";
 import { Deserializer } from "jsonapi-serializer";
 import { getServerSession } from "next-auth";
 import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { authOptions } from "./options";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -179,6 +179,9 @@ export async function getIdeaMemo(uuid: string): Promise<IdeaMemoType> {
       throw new Error("Unauthorized");
     }
     const serializedData = await response.json();
+    if (response.status === 404) {
+      throw new Error("Not Found");
+    }
     if (!response.ok) {
       throw new Error(`データ取得に失敗しました: ${serializedData}`);
     }
@@ -190,6 +193,9 @@ export async function getIdeaMemo(uuid: string): Promise<IdeaMemoType> {
   } catch (error) {
     if (error instanceof Error && error.message === "Unauthorized") {
       redirect("/auth/signin");
+    }
+    if (error instanceof Error && error.message === "Not Found") {
+      return notFound();
     }
     throw new Error(`予期せぬエラーが発生しました: ${error}`);
   }


### PR DESCRIPTION
## issue番号
close #193

## やったこと
アイデアメモ詳細表示時に、存在しない、または自分のアイデアメモではないなどの無効なURLを入力すると、404エラーページを表示するよう修正しました。

## やらないこと
なし

## できるようになること（ユーザ目線）
無効なURLの場合、内部エラーではなく、存在しないページだと伝わるエラーページが表示されるようになります。

## できなくなること（ユーザ目線）
なし

## 動作確認
- 正常なURL
<img width="1364" alt="Screenshot 2024-04-21 at 21 11 10" src="https://github.com/meimei-kr/idea-space-trip/assets/77828683/c52eaff5-8939-45a0-804b-046cffd5ad20">

- 無効なURL
<img width="1377" alt="Screenshot 2024-04-21 at 21 11 40" src="https://github.com/meimei-kr/idea-space-trip/assets/77828683/ffc57fb2-17e0-46af-8dea-94b43082a260">

## その他
なし
