### PR TITLE
fix: レイアウト崩れ修正

### DIFF
--- a/front/src/components/elements/IdeaMemoCard/IdeaMemoCard.module.scss
+++ b/front/src/components/elements/IdeaMemoCard/IdeaMemoCard.module.scss
@@ -37,4 +37,5 @@
   flex-direction: column;
   justify-content: space-between;
   flex: 1;
+  width: 100%;
 }


### PR DESCRIPTION
## やったこと
アイデアメモのレイアウト崩れを修正しました。

## やらないこと
なし

## できるようになること（ユーザ目線）
アイデアメモをレイアウト崩れなく表示させることができます。

## できなくなること（ユーザ目線）
なし

## 動作確認
- 修正前
<img width="464" alt="Screenshot 2024-04-22 at 22 46 50" src="https://github.com/meimei-kr/idea-space-trip/assets/77828683/d0377439-0857-4188-8c1a-f5f02c95950e">


## その他
なし
