### PR TITLE
マイグレーションがデプロイ時に適切に行われるようdocker-entrypoint.shを修正

### DIFF
--- a/back/bin/docker-entrypoint
+++ b/back/bin/docker-entrypoint
@@ -3,4 +3,9 @@
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f /myapp/tmp/pids/server.pid
 
+# If running the rails server then create or migrate existing database
+if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
+  ./bin/rails db:prepare
+fi
+
 exec "${@}"


### PR DESCRIPTION
## やったこと
PlanetScaleを使用していた際に削除していたdocker-entrypoint.shの記述を復元しました。

[理由]
本番環境でマイグレーションが自動で行われないことがあり、上記が原因となっている可能性があるため。

## やらないこと
なし

## できるようになること（ユーザ目線）
なし

## できなくなること（ユーザ目線）
なし

## その他
なし
