### PR TITLE
パフォーマンス改善 #199

### DIFF
--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -8,8 +8,9 @@ const AboutSection = dynamic(() =>
 const FeaturesSection = dynamic(() =>
   import("@/features/home/components").then((mod) => mod.FeaturesSection),
 );
-const LoginSection = dynamic(() =>
-  import("@/features/home/components").then((mod) => mod.LoginSection),
+const LoginSection = dynamic(
+  () => import("@/features/home/components").then((mod) => mod.LoginSection),
+  { ssr: false },
 );
 
 export default async function page() {

--- a/front/src/features/home/components/HeroSection/HeroSection.tsx
+++ b/front/src/features/home/components/HeroSection/HeroSection.tsx
@@ -9,6 +9,7 @@ export default function HeroSection() {
         alt="earth"
         width={502}
         height={497}
+        sizes="(min-width: 1280px) 45vw, 100vw"
         priority={true}
         className={styles.earthImg}
         data-testid="earth"


### PR DESCRIPTION
## issue番号
#199

## やったこと
- モバイルで画像がLCPだと判定されなくなるようにImageにsizesを設定

## やらないこと
なし

## できるようになること（ユーザ目線）
モバイルで画像がLCPだと判定されなくなり、パフォーマンスが向上することを期待します。

## できなくなること（ユーザ目線）
なし

## 動作確認
未確認

## その他
なし
