### PR TITLE
DBボリュームを自動でスケールするようfly.tomlの設定を修正

### DIFF
--- a/back/fly.toml
+++ b/back/fly.toml
@@ -12,6 +12,9 @@ console_command = '/rails/bin/rails console'
 [[mounts]]
   source = 'idea_space_trip_db'
   destination = '/data'
+  auto_extend_size_threshold = 90
+  auto_extend_size_increment = "1GB"
+  auto_extend_size_limit = "3GB"
 
 [[services]]
   internal_port = 3000


### PR DESCRIPTION
## やったこと
- fly.ioのPostgreSQLのボリューム上限に近づくと自動でスケールされるよう設定

## やらないこと
なし

## できるようになること（ユーザ目線）
PostgreSQLのボリューム不足によるアプリのエラーや停止を防げます。

## できなくなること（ユーザ目線）
なし

## 動作確認
なし

## その他
なし
