### PR TITLE
Sentryの監視トランザクションを節約するための設定変更

### DIFF
--- a/front/sentry.client.config.ts
+++ b/front/sentry.client.config.ts
@@ -8,7 +8,7 @@ Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
+  tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
@@ -17,7 +17,7 @@ Sentry.init({
 
   // This sets the sample rate to be 10%. You may want this to be 100% while
   // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
+  replaysSessionSampleRate: 0.01,
 
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [

--- a/front/sentry.edge.config.ts
+++ b/front/sentry.edge.config.ts
@@ -9,7 +9,7 @@ Sentry.init({
   dsn: "https://b865a2df79f545d3d458fc67c7e946d3@o4506995458768896.ingest.us.sentry.io/4506995466240000",
 
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
+  tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/front/sentry.server.config.ts
+++ b/front/sentry.server.config.ts
@@ -8,7 +8,7 @@ Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
+  tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,


### PR DESCRIPTION
## やったこと
- `Performance Unit Capacity Used` が無料使用上限に達したため、サンプリングデータを取得する割合を減らすため、`tracesSampleRate`の値を変更しました。
- `Replay Capacity Used`が無料使用上限に達したため、エラーの有無に関わらずユーザーのセッション全体に渡って計測する比率である `replaysSessionSampleRate`の値を変更しました。

## やらないこと
なし

## できるようになること（ユーザ目線）


## できなくなること（ユーザ目線）
なし

## 動作確認
-

## その他
なし
