### PR TITLE
--platformの指定を削除

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -3,7 +3,7 @@
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version
 ARG RUBY_VERSION=3.4.4
-FROM --platform=linux/amd64 ruby:$RUBY_VERSION-slim AS base
+FROM ruby:$RUBY_VERSION-slim AS base
 
 LABEL fly_launch_runtime="rails"
 


### PR DESCRIPTION
## 内容
自動生成されたものだが、--platformでリテラル指定するとNGっぽいので削除してみる

https://docs.docker.com/reference/build-checks/from-platform-flag-const-disallowed/